### PR TITLE
[테트리스] ux 개선

### DIFF
--- a/tetris/README.md
+++ b/tetris/README.md
@@ -29,7 +29,7 @@
 - block을 rotate하는 로직이 필요하다. 이건 결국 행렬의 90도 변환이다. 2x3행렬이 3x2행렬로 변할 수 있음도 고려하자.
   - 이런 독립적이고 복잡한 케이스는 TDD로 구현하면 좋다.
 
-## 게임-1
+## 게임-1(UI 컴포넌트, useTetrisGame 훅 생성)
 
 - 먼저 UI부터 생각하자
   - 게임이 진행되는 테이블과 다음 블록을 그려줘야한다.
@@ -49,7 +49,7 @@
   - useEffect의 사용은 최대한 지양하는게 좋다. 그렇기 때문에 useEffect를 최대한 사용하지 않다보니 if if if와 같은 문법이 나왔다. 가독성을 위해 early return 형태로 개선했다.
   - 아무리 역할과 책임으로 분리해도 리액트에서는 UI와 데이터를 다루는 로직이 섞이기 마련이다. 그래서 useTetrisGame으로 최대한 데이터를 다루는 부분을 추상화했다. 또한 UI를 다루는쪽에서 불필요한 코드는 외부로 노출시키지 않았다.
 
-## 게임-2
+## 게임-2(기본적인 게임 형태 구현)
 
 - combineBlockWithPosition에 오류가 있는것을 발견했다.
   - 이건 내가 잘못 생각한거라 테스트코드로도 방어할 수 없다.
@@ -68,6 +68,24 @@
       - 생각나는 방법으로는 setState를 훅의 인터페이스에 노출시키기, clearLine상태를 외부에서 주입받기가 있다. 둘다 별로 원하는 방식은 아니다...
       - getGoalClearLine이라는 함수를 만들었는데 이걸 모킹하면 훅의 변화없이도 가능하다는 것을 깨달았다! 이렇게 해야겠다.
     - 기본적인 테스트만 작성했는데 꽤 많은 테스트케이스가 나왔다. 엄청 어렵지는 않지만 엄청 쉽지도 않다. 연습이 필요할 것 같다.
+
+## 게임-3(ux 개선)
+
+- block row position이 음수일때도 가능하게 개선
+  - 항상 i블록이 말썽이다.. i 블록 케이스를 대응하기 위해서 작업을 했는데 생각보다 시간이 많이 걸렸다.. 그래도 TDD 방식으로 개선하다보니 훨씬 수월했다.
+  - i블록의 경우 rotate상태에 따라서 맨 왼쪽 혹은 맨 오른쪽으로 이동할 수 없는 문제가 존재했다. (row position이 0이여도 실제 ui는 맨 왼쪽에 있지 않기 때문에)
+  ```
+  [
+    [false,false,true,false],
+    [false,false,true,false],
+    [false,false,true,false],
+    [false,false,true,false],
+  ]
+  ```
+- 블록 shape 변경
+  - ux 개선 및 양끝에서 회전을 쉽게 구현하기 위해서 블록 shape를 변경했다.(https://tetr.io/, https://tetris.com/play-tetris 참고)
+- 블록이 맨 왼쪽이나 오른쪽에 있을 때 회전되지 않는 문제 해결
+  - 다른 테트리스 게임을 해보니 position을 변경시켜서 회전을 시켜주고 있었다. currentBlock.shape를 이용해서 변경할 position을 구하고 기존에 만들어둔 getIsPossibleRender을 이용해서 렌더링가능 여부를 확인한 후 position과 block을 동시에 변경시켰다.
 
 # React + TypeScript + Vite
 

--- a/tetris/src/pages/play/helper/block.spec.ts
+++ b/tetris/src/pages/play/helper/block.spec.ts
@@ -35,6 +35,7 @@ describe('combineBlockWithPosition', () => {
       expect(combineBlockWithPosition(BLOCK_MAP.l, { col: 0, row: 2 })).toEqual([
         [null, null, null, null, 'l'],
         [null, null, 'l', 'l', 'l'],
+        [null, null, null, null, null],
       ]);
     });
     it('t블록이 성공적으로 변환된다.', () => {

--- a/tetris/src/pages/play/helper/block.spec.ts
+++ b/tetris/src/pages/play/helper/block.spec.ts
@@ -105,15 +105,15 @@ describe('combineBlockWithPosition', () => {
   it('col이 0이고 row가 -1일 때 i 블록이 성공적으로 변환된다.', () => {
     const block: Block = { type: 'i', shape: rotateClockWiseIn2DArr(BLOCK_MAP['i'].shape) };
     expect(combineBlockWithPosition(block, { col: 0, row: -1 })).toEqual([
-      [null, null, 'i', null],
-      [null, null, 'i', null],
-      [null, null, 'i', null],
-      [null, null, 'i', null],
+      [null, 'i', null, null],
+      [null, 'i', null, null],
+      [null, 'i', null, null],
+      [null, 'i', null, null],
     ]);
   });
-  it('col이 0이고 row가 -3일 때 i 블록이 성공적으로 변환된다.', () => {
+  it('col이 0이고 row가 -2일 때 i 블록이 성공적으로 변환된다.', () => {
     const block: Block = { type: 'i', shape: rotateClockWiseIn2DArr(BLOCK_MAP['i'].shape) };
-    expect(combineBlockWithPosition(block, { col: 0, row: -3 })).toEqual([
+    expect(combineBlockWithPosition(block, { col: 0, row: -2 })).toEqual([
       ['i', null, null, null],
       ['i', null, null, null],
       ['i', null, null, null],

--- a/tetris/src/pages/play/helper/block.spec.ts
+++ b/tetris/src/pages/play/helper/block.spec.ts
@@ -41,12 +41,14 @@ describe('combineBlockWithPosition', () => {
       expect(combineBlockWithPosition(BLOCK_MAP.t, { col: 0, row: 2 })).toEqual([
         [null, null, null, 't', null],
         [null, null, 't', 't', 't'],
+        [null, null, null, null, null],
       ]);
     });
     it('s블록이 성공적으로 변환된다.', () => {
       expect(combineBlockWithPosition(BLOCK_MAP.s, { col: 0, row: 2 })).toEqual([
         [null, null, null, 's', 's'],
         [null, null, 's', 's', null],
+        [null, null, null, null, null],
       ]);
     });
   });

--- a/tetris/src/pages/play/helper/block.spec.ts
+++ b/tetris/src/pages/play/helper/block.spec.ts
@@ -102,4 +102,22 @@ describe('combineBlockWithPosition', () => {
       [null, null, null, null, null, null, null, null, null, null, null, null, null, null],
     ]);
   });
+  it('col이 0이고 row가 -1일 때 i 블록이 성공적으로 변환된다.', () => {
+    const block: Block = { type: 'i', shape: rotateClockWiseIn2DArr(BLOCK_MAP['i'].shape) };
+    expect(combineBlockWithPosition(block, { col: 0, row: -1 })).toEqual([
+      [null, null, 'i', null],
+      [null, null, 'i', null],
+      [null, null, 'i', null],
+      [null, null, 'i', null],
+    ]);
+  });
+  it('col이 0이고 row가 -3일 때 i 블록이 성공적으로 변환된다.', () => {
+    const block: Block = { type: 'i', shape: rotateClockWiseIn2DArr(BLOCK_MAP['i'].shape) };
+    expect(combineBlockWithPosition(block, { col: 0, row: -3 })).toEqual([
+      ['i', null, null, null],
+      ['i', null, null, null],
+      ['i', null, null, null],
+      ['i', null, null, null],
+    ]);
+  });
 });

--- a/tetris/src/pages/play/helper/block.ts
+++ b/tetris/src/pages/play/helper/block.ts
@@ -35,6 +35,7 @@ export const BLOCK_MAP: Record<BlockType, Block> = {
   t: {
     type: 't',
     shape: [
+      [false, false, false],
       [false, true, false],
       [true, true, true],
     ],
@@ -42,6 +43,7 @@ export const BLOCK_MAP: Record<BlockType, Block> = {
   s: {
     type: 's',
     shape: [
+      [false, false, false],
       [false, true, true],
       [true, true, false],
     ],
@@ -49,6 +51,7 @@ export const BLOCK_MAP: Record<BlockType, Block> = {
   z: {
     type: 'z',
     shape: [
+      [false, false, false],
       [true, true, false],
       [false, true, true],
     ],

--- a/tetris/src/pages/play/helper/block.ts
+++ b/tetris/src/pages/play/helper/block.ts
@@ -21,6 +21,7 @@ export const BLOCK_MAP: Record<BlockType, Block> = {
   l: {
     type: 'l',
     shape: [
+      [false, false, false],
       [false, false, true],
       [true, true, true],
     ],
@@ -28,6 +29,7 @@ export const BLOCK_MAP: Record<BlockType, Block> = {
   j: {
     type: 'j',
     shape: [
+      [false, false, false],
       [true, false, false],
       [true, true, true],
     ],

--- a/tetris/src/pages/play/helper/block.ts
+++ b/tetris/src/pages/play/helper/block.ts
@@ -5,8 +5,8 @@ export const BLOCK_MAP: Record<BlockType, Block> = {
   i: {
     type: 'i',
     shape: [
-      [true, true, true, true],
       [false, false, false, false],
+      [true, true, true, true],
       [false, false, false, false],
       [false, false, false, false],
     ],
@@ -88,7 +88,9 @@ export const combineBlockWithPosition = (block: Block, blockPosition: Position) 
   ) as Table;
   const addCol = blockPosition.col;
   const addRow = blockPosition.row;
-  block.shape.forEach((blockShapeCol, col) => {
+  // NOTE: 맨 위 block이 비어있는 경우 제거해줍니다. ex) i블록
+  const filteredBlockShape = block.shape.filter((shapeCol) => !shapeCol.every((isExist) => !isExist));
+  filteredBlockShape.forEach((blockShapeCol, col) => {
     blockShapeCol.forEach((isExistBlock, row) => {
       if (isExistBlock) {
         table[col + addCol][row + addRow] = block.type;

--- a/tetris/src/pages/play/helper/block.ts
+++ b/tetris/src/pages/play/helper/block.ts
@@ -83,8 +83,8 @@ export const getBlockBottomPosition = (block: Block, blockPosition: Position) =>
 export const combineBlockWithPosition = (block: Block, blockPosition: Position) => {
   const blockColLength = block.shape.length;
   const blockRowLength = block.shape[0].length;
-  const table = [...Array(blockPosition.col + blockColLength)].map(() =>
-    Array(blockPosition.row + blockRowLength).fill(null),
+  const table = [...Array(Math.max(blockPosition.col, 0) + blockColLength)].map(() =>
+    Array(Math.max(blockPosition.row, 0) + blockRowLength).fill(null),
   ) as Table;
   const addCol = blockPosition.col;
   const addRow = blockPosition.row;

--- a/tetris/src/pages/play/helper/table.spec.ts
+++ b/tetris/src/pages/play/helper/table.spec.ts
@@ -6,7 +6,8 @@ import {
   getIsPossibleRender,
   getUpdateTableByCompletedLines,
 } from './table';
-import { Table } from './types';
+import { Block, Table } from './types';
+import { rotateClockWiseIn2DArr } from './utils';
 
 describe('getEmptyTable', () => {
   it('col이 3이고 row가 2인 empty table을 만든다.', () => {
@@ -77,6 +78,36 @@ describe('getIsPossibleRender', () => {
         { col: 0, row: 2 },
       ),
     ).toBe(true);
+  });
+  it('row가 -1인 경우 i블록은 렌더링이 가능하다.', () => {
+    const block: Block = { type: 'i', shape: rotateClockWiseIn2DArr(BLOCK_MAP['i'].shape) };
+    expect(
+      getIsPossibleRender(
+        [
+          [null, null, null, null, null, null],
+          [null, null, null, null, null, null],
+          [null, null, null, null, null, null],
+          [null, null, null, null, null, null],
+        ],
+        block,
+        { col: 0, row: -1 },
+      ),
+    ).toBe(true);
+  });
+  it('row가 -4인 경우 i블록은 렌더링이 가능하지 않다.', () => {
+    const block: Block = { type: 'i', shape: rotateClockWiseIn2DArr(BLOCK_MAP['i'].shape) };
+    expect(
+      getIsPossibleRender(
+        [
+          [null, null, null, null, null, null],
+          [null, null, null, null, null, null],
+          [null, null, null, null, null, null],
+          [null, null, null, null, null, null],
+        ],
+        block,
+        { col: 0, row: -4 },
+      ),
+    ).toBe(false);
   });
   describe('position을 벗어나는 경우', () => {
     it('column이 넘친다면 렌더링이 가능하지 않다.', () => {

--- a/tetris/src/pages/play/helper/table.ts
+++ b/tetris/src/pages/play/helper/table.ts
@@ -30,10 +30,42 @@ export const findCompletedLines = (table: Table) => {
   }, []);
 };
 
+function getCellLength<T>(table: T[][]) {
+  return table.reduce(
+    (acc, cur) =>
+      acc +
+      cur.reduce((ac, cu) => {
+        if (cu !== null) {
+          return ac + 1;
+        }
+        return ac;
+      }, 0),
+    0,
+  );
+}
+
+function getBlockLength<T>(table: T[][]) {
+  return table.reduce(
+    (acc, cur) =>
+      acc +
+      cur.reduce((ac, cu) => {
+        if (cu) {
+          return ac + 1;
+        }
+        return ac;
+      }, 0),
+    0,
+  );
+}
+
 export const getIsPossibleRender = (table: Table, block: Block, blockPosition: Position) => {
+  const blockWithPosition = combineBlockWithPosition(block, blockPosition);
+  const cellLength = getCellLength(blockWithPosition);
+  const blockLength = getBlockLength(block.shape);
+
   const invalidBlockPosition =
     blockPosition.col < 0 ||
-    blockPosition.row < 0 ||
+    cellLength !== blockLength ||
     blockPosition.col > table.length ||
     blockPosition.row > table[0].length;
   if (invalidBlockPosition) {
@@ -45,7 +77,6 @@ export const getIsPossibleRender = (table: Table, block: Block, blockPosition: P
     return false;
   }
 
-  const blockWithPosition = combineBlockWithPosition(block, blockPosition);
   for (let col = 0; col < blockWithPosition.length; col++) {
     for (let row = 0; row < blockWithPosition[0].length; row++) {
       if (blockWithPosition[col][row] !== null && table[col][row] !== null) {

--- a/tetris/src/pages/play/hooks/useTetrisGame.spec.ts
+++ b/tetris/src/pages/play/hooks/useTetrisGame.spec.ts
@@ -235,7 +235,7 @@ describe('useTetrisGame', () => {
     });
   });
 
-  describe('interval callback 테스트', () => {
+  describe('interval callback', () => {
     it('블록 아래 position이 비어있다면 아래로 이동한다.', () => {
       const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
 

--- a/tetris/src/pages/play/hooks/useTetrisGame.spec.ts
+++ b/tetris/src/pages/play/hooks/useTetrisGame.spec.ts
@@ -152,26 +152,42 @@ describe('useTetrisGame', () => {
   it('블록이 회전할 수 없는 경우 블록이 회전되지 않는다.', () => {
     function getMockTable() {
       const result = helperModule.getEmptyTable();
-      for (let col = 0; col < result.length; col++) {
-        for (let row = 0; row < result[0].length / 2 - 1; row++) {
+      for (let col = 3; col < result.length; col++) {
+        for (let row = 0; row < result[0].length / 2 - 2; row++) {
           result[col][row] = 'i';
         }
-        for (let row = result[0].length / 2 + 1; row < result[0].length; row++) {
+        for (let row = result[0].length / 2; row < result[0].length; row++) {
           result[col][row] = 'i';
         }
       }
       return result;
     }
     jest.spyOn(helperModule, 'getEmptyTable').mockReturnValue(getMockTable());
-    jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
-
+    // NOTE: l 블록 모킹(7개중 3번째)
+    jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(5 / 14));
     const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
+
+    // NOTE: setState batching 때문에 여러 act로 처리
+    act(() => {
+      result.current.handleChangeRotateBlock();
+    });
+    act(() => {
+      result.current.handleChangeDownPosition();
+    });
+    act(() => {
+      result.current.handleChangeDownPosition();
+    });
+    act(() => {
+      result.current.handleChangeDownPosition();
+    });
+    act(() => {
+      result.current.handleChangeDownPosition();
+    });
 
     const beforeTableForRender = result.current.tableForRender;
     act(() => {
       result.current.handleChangeRotateBlock();
     });
-
     expect(beforeTableForRender).toEqual(result.current.tableForRender);
   });
 

--- a/tetris/src/pages/play/hooks/useTetrisGame.spec.ts
+++ b/tetris/src/pages/play/hooks/useTetrisGame.spec.ts
@@ -136,59 +136,103 @@ describe('useTetrisGame', () => {
     expect(beforeBlockForRender).not.toEqual(result.current.blockForRender);
   });
 
-  it('블록이 회전할 수 있는 경우 블록이 정상적으로 회전한다.', () => {
-    // NOTE: o블록은 회전해도 변하지 않아서 모킹이 필요함
-    jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
-    const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
+  describe('블록 회전', () => {
+    it('블록이 정상적으로 회전한다.', () => {
+      // NOTE: o블록은 회전해도 변하지 않아서 모킹이 필요함
+      jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
+      const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
 
-    const beforeTableForRender = result.current.tableForRender;
-    act(() => {
-      result.current.handleChangeRotateBlock();
+      const beforeTableForRender = result.current.tableForRender;
+      act(() => {
+        result.current.handleChangeRotateBlock();
+      });
+
+      expect(beforeTableForRender).not.toEqual(result.current.tableForRender);
     });
 
-    expect(beforeTableForRender).not.toEqual(result.current.tableForRender);
-  });
+    it('i블록을 회전하고 position을 맨 왼쪽으로 이동했을 때 블록이 정상적으로 회전한다.', () => {
+      jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
+      const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
 
-  it('블록이 회전할 수 없는 경우 블록이 회전되지 않는다.', () => {
-    function getMockTable() {
-      const result = helperModule.getEmptyTable();
-      for (let col = 3; col < result.length; col++) {
-        for (let row = 0; row < result[0].length / 2 - 2; row++) {
-          result[col][row] = 'i';
-        }
-        for (let row = result[0].length / 2; row < result[0].length; row++) {
-          result[col][row] = 'i';
-        }
+      act(() => {
+        result.current.handleChangeRotateBlock();
+      });
+      for (let i = 0; i < helperModule.SETTINGS.row / 2; i++) {
+        act(() => {
+          result.current.handleChangeLeftPosition();
+        });
       }
-      return result;
-    }
-    jest.spyOn(helperModule, 'getEmptyTable').mockReturnValue(getMockTable());
-    // NOTE: l 블록 모킹(7개중 3번째)
-    jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(5 / 14));
-    const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
 
-    // NOTE: setState batching 때문에 여러 act로 처리
-    act(() => {
-      result.current.handleChangeRotateBlock();
-    });
-    act(() => {
-      result.current.handleChangeDownPosition();
-    });
-    act(() => {
-      result.current.handleChangeDownPosition();
-    });
-    act(() => {
-      result.current.handleChangeDownPosition();
-    });
-    act(() => {
-      result.current.handleChangeDownPosition();
+      const beforeTableForRender = result.current.tableForRender;
+      act(() => {
+        result.current.handleChangeRotateBlock();
+      });
+
+      expect(beforeTableForRender).not.toEqual(result.current.tableForRender);
     });
 
-    const beforeTableForRender = result.current.tableForRender;
-    act(() => {
-      result.current.handleChangeRotateBlock();
+    it('i블록을 회전하고 position을 맨 오른쪽으로 이동했을 때 블록이 정상적으로 회전한다.', () => {
+      jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
+      const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
+
+      act(() => {
+        result.current.handleChangeRotateBlock();
+      });
+      for (let i = 0; i < helperModule.SETTINGS.row / 2; i++) {
+        act(() => {
+          result.current.handleChangeRightPosition();
+        });
+      }
+
+      const beforeTableForRender = result.current.tableForRender;
+      act(() => {
+        result.current.handleChangeRotateBlock();
+      });
+
+      expect(beforeTableForRender).not.toEqual(result.current.tableForRender);
     });
-    expect(beforeTableForRender).toEqual(result.current.tableForRender);
+
+    it('블록이 회전할 수 없는 경우 블록이 회전되지 않는다.', () => {
+      function getMockTable() {
+        const result = helperModule.getEmptyTable();
+        for (let col = 3; col < result.length; col++) {
+          for (let row = 0; row < result[0].length / 2 - 2; row++) {
+            result[col][row] = 'i';
+          }
+          for (let row = result[0].length / 2; row < result[0].length; row++) {
+            result[col][row] = 'i';
+          }
+        }
+        return result;
+      }
+      jest.spyOn(helperModule, 'getEmptyTable').mockReturnValue(getMockTable());
+      // NOTE: l 블록 모킹(7개중 3번째)
+      jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(5 / 14));
+      const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
+
+      // NOTE: setState batching 때문에 여러 act로 처리
+      act(() => {
+        result.current.handleChangeRotateBlock();
+      });
+      act(() => {
+        result.current.handleChangeDownPosition();
+      });
+      act(() => {
+        result.current.handleChangeDownPosition();
+      });
+      act(() => {
+        result.current.handleChangeDownPosition();
+      });
+      act(() => {
+        result.current.handleChangeDownPosition();
+      });
+
+      const beforeTableForRender = result.current.tableForRender;
+      act(() => {
+        result.current.handleChangeRotateBlock();
+      });
+      expect(beforeTableForRender).toEqual(result.current.tableForRender);
+    });
   });
 
   describe('interval callback 테스트', () => {

--- a/tetris/src/pages/play/hooks/useTetrisGame.ts
+++ b/tetris/src/pages/play/hooks/useTetrisGame.ts
@@ -83,6 +83,29 @@ export const useTetrisGame = (
     const nextBlock = { ...currentBlock, shape: rotateClockWiseIn2DArr(currentBlock.shape) };
     if (getIsPossibleRender(table, nextBlock, currentBlockPosition)) {
       setCurrentBlock(nextBlock);
+      return;
+    }
+
+    const leftEmptyRowCount = currentBlock.shape.reduce((acc, cur) => {
+      const currentCount = cur.findIndex((v) => v === true);
+      return Math.min(acc, currentCount);
+    }, Infinity);
+    const leftChangedPosition = { col: currentBlockPosition.col, row: currentBlockPosition.row + leftEmptyRowCount };
+    if (getIsPossibleRender(table, nextBlock, leftChangedPosition)) {
+      setCurrentBlockPosition(leftChangedPosition);
+      setCurrentBlock(nextBlock);
+      return;
+    }
+
+    const rightEmptyRowCount = currentBlock.shape.reduce((acc, cur) => {
+      const currentCount = cur.reverse().findIndex((v) => v === true);
+      return Math.min(acc, currentCount);
+    }, Infinity);
+    const rightChangedPosition = { col: currentBlockPosition.col, row: currentBlockPosition.row - rightEmptyRowCount };
+    if (getIsPossibleRender(table, nextBlock, rightChangedPosition)) {
+      setCurrentBlockPosition(rightChangedPosition);
+      setCurrentBlock(nextBlock);
+      return;
     }
   });
 


### PR DESCRIPTION
## 요약

- ux 개선

---

README

## 게임-3(ux 개선)

- block row position이 음수일때도 가능하게 개선
  - 항상 i블록이 말썽이다.. i 블록 케이스를 대응하기 위해서 작업을 했는데 생각보다 시간이 많이 걸렸다.. 그래도 TDD 방식으로 개선하다보니 훨씬 수월했다.
  - i블록의 경우 rotate상태에 따라서 맨 왼쪽 혹은 맨 오른쪽으로 이동할 수 없는 문제가 존재했다. (row position이 0이여도 실제 ui는 맨 왼쪽에 있지 않기 때문에)
  ```
  [
    [false,false,true,false],
    [false,false,true,false],
    [false,false,true,false],
    [false,false,true,false],
  ]
  ```
- 블록 shape 변경
  - ux 개선 및 양끝에서 회전을 쉽게 구현하기 위해서 블록 shape를 변경했다.(https://tetr.io/, https://tetris.com/play-tetris 참고)
- 블록이 맨 왼쪽이나 오른쪽에 있을 때 회전되지 않는 문제 해결
  - 다른 테트리스 게임을 해보니 position을 변경시켜서 회전을 시켜주고 있었다. currentBlock.shape를 이용해서 변경할 position을 구하고 기존에 만들어둔 getIsPossibleRender을 이용해서 렌더링가능 여부를 확인한 후 position과 block을 동시에 변경시켰다.