### PR TITLE
[테트리스] 그림자 추가

### DIFF
--- a/tetris/README.md
+++ b/tetris/README.md
@@ -87,6 +87,11 @@
 - 블록이 맨 왼쪽이나 오른쪽에 있을 때 회전되지 않는 문제 해결
   - 다른 테트리스 게임을 해보니 position을 변경시켜서 회전을 시켜주고 있었다. currentBlock.shape를 이용해서 변경할 position을 구하고 기존에 만들어둔 getIsPossibleRender을 이용해서 렌더링가능 여부를 확인한 후 position과 block을 동시에 변경시켰다.
 
+## 게임4(그림자)
+
+- ux가 크게 개선되는 그림자 작업을 추가했다.
+- 기존에 handleChangeLastBottomPosition에서 하는 코드를 거의 그대로 옮긴거라서 작업은 어렵지 않다.
+
 # React + TypeScript + Vite
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.

--- a/tetris/src/pages/play/_components/CellBlock.tsx
+++ b/tetris/src/pages/play/_components/CellBlock.tsx
@@ -1,4 +1,4 @@
-import { BlockType, Cell } from '../helper';
+import { Cell } from '../helper';
 
 interface CellProps {
   blockType: Cell;
@@ -12,7 +12,7 @@ function CellBlock({ blockType }: CellProps) {
 
 export default CellBlock;
 
-const getBlocStyle = (cell: BlockType | null) => {
+const getBlocStyle = (cell: Cell) => {
   switch (cell) {
     case 'i':
       return 'red';
@@ -28,6 +28,8 @@ const getBlocStyle = (cell: BlockType | null) => {
       return 'indigo';
     case 'z':
       return 'purple';
+    case 'shadow':
+      return 'lightgray';
     case null:
     default:
       return undefined;

--- a/tetris/src/pages/play/helper/index.ts
+++ b/tetris/src/pages/play/helper/index.ts
@@ -4,6 +4,7 @@ export { SETTINGS } from './constants';
 export { getGameSpeed } from './speed';
 export {
   combineBlockWithTable,
+  getTableForRenderer,
   getEmptyTable,
   findCompletedLines,
   getIsPossibleRender,

--- a/tetris/src/pages/play/helper/table.spec.ts
+++ b/tetris/src/pages/play/helper/table.spec.ts
@@ -4,6 +4,7 @@ import {
   findCompletedLines,
   getEmptyTable,
   getIsPossibleRender,
+  getTableForRenderer,
   getUpdateTableByCompletedLines,
 } from './table';
 import { Block, Table } from './types';
@@ -27,6 +28,19 @@ it('combineBlockWithTable', () => {
     [null, null, null, null, null],
     [null, null, null, null, null],
   ]);
+});
+
+it('getTableForRenderer', () => {
+  expect(getTableForRenderer(getEmptyTable(5, 5), BLOCK_MAP['j'], { col: 0, row: 2 })).toEqual({
+    nextCol: 3,
+    tableForRender: [
+      [null, null, 'j', null, null],
+      [null, null, 'j', 'j', 'j'],
+      [null, null, null, null, null],
+      [null, null, 'shadow', null, null],
+      [null, null, 'shadow', 'shadow', 'shadow'],
+    ],
+  });
 });
 
 describe('findCompletedLines', () => {

--- a/tetris/src/pages/play/helper/table.ts
+++ b/tetris/src/pages/play/helper/table.ts
@@ -21,6 +21,28 @@ export const combineBlockWithTable = (table: Table, block: Block, blockPosition:
   return nextTable;
 };
 
+export const getTableForRenderer = (table: Table, block: Block, blockPosition: Position) => {
+  let nextCol = blockPosition.col;
+  while (getIsPossibleRender(table, block, { col: nextCol, row: blockPosition.row })) {
+    nextCol += 1;
+  }
+  nextCol = Math.max(nextCol - 1, 0);
+
+  const blockWithTable = combineBlockWithTable(table, block, blockPosition);
+  const shadowTable = combineBlockWithPosition(block, { col: nextCol, row: blockPosition.row });
+
+  const tableForRender = produce(blockWithTable, (draft) => {
+    shadowTable.forEach((blockShapeCol, col) => {
+      blockShapeCol.forEach((blockShape, row) => {
+        if (draft[col]?.[row] === null && blockShape) {
+          draft[col][row] = 'shadow';
+        }
+      });
+    });
+  });
+  return { tableForRender, nextCol };
+};
+
 export const findCompletedLines = (table: Table) => {
   return table.reduce<number[]>((acc, cur, index) => {
     if (cur.every((v) => v !== null)) {

--- a/tetris/src/pages/play/helper/types.ts
+++ b/tetris/src/pages/play/helper/types.ts
@@ -5,7 +5,7 @@ export interface Block {
   shape: BlockShape;
 }
 
-export type Cell = BlockType | null;
+export type Cell = BlockType | 'shadow' | null;
 export type Table = Cell[][];
 
 export type Position = { row: number; col: number };

--- a/tetris/src/pages/play/hooks/useTetrisGame.ts
+++ b/tetris/src/pages/play/hooks/useTetrisGame.ts
@@ -11,6 +11,7 @@ import {
   getGoalClearLine,
   getIsPossibleRender,
   getRandomBlock,
+  getTableForRenderer,
   getUpdateTableByCompletedLines,
   rotateClockWiseIn2DArr,
 } from '../helper';
@@ -40,7 +41,7 @@ export const useTetrisGame = (
 
   const goalClearLine = getGoalClearLine(stage);
   const blockForRender = combineBlockWithTable(blockEmptyTable, nextBlock, { col: 0, row: 0 });
-  const tableForRender = combineBlockWithTable(table, currentBlock, currentBlockPosition);
+  const { tableForRender, nextCol } = getTableForRenderer(table, currentBlock, currentBlockPosition);
 
   const intervalCallback = () => {
     const isPossibleDownRender = getIsPossibleRender(table, currentBlock, {
@@ -110,11 +111,7 @@ export const useTetrisGame = (
   });
 
   const handleChangeLastBottomPosition = usePreservedCallback(() => {
-    let nextCol = currentBlockPosition.col;
-    while (getIsPossibleRender(table, currentBlock, { col: nextCol, row: currentBlockPosition.row })) {
-      nextCol += 1;
-    }
-    setCurrentBlockPosition({ col: Math.max(nextCol - 1, 0), row: currentBlockPosition.row });
+    setCurrentBlockPosition((position) => ({ col: nextCol, row: position.row }));
     setIsCrashed(true);
   });
 


### PR DESCRIPTION
## 요약

- 테트리스에 현재 블록이 최하단에 갔을 때 렌더링되는 모양을 그림자로 보여주는 getTableForRenderer 추가합니다.
- `handleChangeLastBottomPosition` 내의 로직을 getTableForRenderer함수로 이동합니다.

## 테스트 커버리지

<img width="637" alt="스크린샷 2024-05-15 오후 7 14 46" src="https://github.com/yoonminsang/TIL/assets/57904979/e184a0f6-e5a6-4a7d-98bd-6b776d17c199">

## 영상

https://github.com/yoonminsang/TIL/assets/57904979/b672ffa5-92aa-478a-bac2-b2fd05a4f80a

---
README

## 게임4(그림자)

- ux가 크게 개선되는 그림자 작업을 추가했다.
- 기존에 handleChangeLastBottomPosition에서 하는 코드를 거의 그대로 옮긴거라서 작업은 어렵지 않다.