### PR TITLE
[테트리스] 기타(1차 마무리)

### DIFF
--- a/tetris/.eslintrc.cjs
+++ b/tetris/.eslintrc.cjs
@@ -1,14 +1,18 @@
 module.exports = {
   root: true,
   env: { browser: true, es2020: true },
-  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:react-hooks/recommended', 'plugin:storybook/recommended'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:storybook/recommended',
+    /** https://github.com/prettier/eslint-plugin-prettier#recommended-configuration */
+    'plugin:prettier/recommended',
+  ],
   ignorePatterns: ['dist', '.eslintrc.cjs'],
   parser: '@typescript-eslint/parser',
   plugins: ['react-refresh'],
   rules: {
-    'react-refresh/only-export-components': [
-      'warn',
-      { allowConstantExport: true },
-    ],
+    'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
   },
-}
+};

--- a/tetris/README.md
+++ b/tetris/README.md
@@ -92,6 +92,21 @@
 - ux가 크게 개선되는 그림자 작업을 추가했다.
 - 기존에 handleChangeLastBottomPosition에서 하는 코드를 거의 그대로 옮긴거라서 작업은 어렵지 않다.
 
+## 게임5(기타)
+
+- space를 누르고 있을 때 여러번 이벤트가 발생하는 실수를 막는 기능 추가
+- space를 누를 때 시간 delay를 초기화시키는 기능 추가
+  - intervalcallback이 1초마다 실행된다고 가정했을 때 0.9초에 space를 누르면 0.1초후에 다음 블록이 내려오고 있었음. 다른 테트리스 게임으로 테스트를 해보고 delay를 초기화시키는 방법으로 변경함
+- dead를 판단하는 시점 변경
+  - intervalcallback에서 실행하면 계속 space를 누를때 영원히 intervalcallback이 실행되지 않아서 죽지 않는 현상 발생
+  - crash가 발생했을 때 dead여부를 판단해주면 위와같은 버그도 사라지고 더 빠른 진행이 가능하다
+- holdblock 기능 추가
+- 시계반대방향 회전 이벤트 핸들러 추가(control)
+- 블록에 대한 UI와 기능을 분리
+  - 기존에는 훅에서 렌더링하기 위한 변환과정까지 끝내서 넘겨주고 있었는데 이렇게 하면 UI와 데이터가 결합되는 문제가 있다.
+  - tableForRender는 현재 block과 table 두개를 결합해서 사용되고 훅 내부에서도 사용되기 때문에 일단은 훅 내부에서 관리함
+- 테스트코드 오류 전부 수정
+
 # React + TypeScript + Vite
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.

--- a/tetris/package-lock.json
+++ b/tetris/package-lock.json
@@ -44,6 +44,8 @@
         "@vitejs/plugin-react-swc": "^3.5.0",
         "autoprefixer": "^10.4.19",
         "eslint": "^8.57.0",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.6",
         "eslint-plugin-storybook": "^0.8.0",
@@ -3421,6 +3423,18 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/@radix-ui/react-compose-refs": {
@@ -8275,6 +8289,48 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.3.tgz",
+      "integrity": "sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==",
+      "dev": true,
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.8.6"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": "*",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
@@ -8712,6 +8768,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
     "node_modules/fast-glob": {
@@ -12864,6 +12926,18 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/prettier-plugin-tailwindcss": {
       "version": "0.5.14",
       "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.14.tgz",
@@ -14384,6 +14458,28 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
+    "node_modules/synckit": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
+      "integrity": "sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==",
+      "dev": true,
+      "dependencies": {
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/synckit/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
       "dev": true
     },
     "node_modules/tailwind-merge": {

--- a/tetris/package.json
+++ b/tetris/package.json
@@ -49,6 +49,8 @@
     "@vitejs/plugin-react-swc": "^3.5.0",
     "autoprefixer": "^10.4.19",
     "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.6",
     "eslint-plugin-storybook": "^0.8.0",

--- a/tetris/package.json
+++ b/tetris/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint:fix": "npm run lint -- --fix",
     "preview": "vite preview",
     "test": "jest",
     "storybook": "storybook dev -p 6006",

--- a/tetris/src/App.tsx
+++ b/tetris/src/App.tsx
@@ -18,7 +18,7 @@ function App() {
   const { stage, increase: increaseStage } = useStage(
     useShallow(({ stage, increase }) => {
       return { stage, increase };
-    }),
+    })
   );
 
   return (

--- a/tetris/src/__test__/DeadPage.spec.tsx
+++ b/tetris/src/__test__/DeadPage.spec.tsx
@@ -1,62 +1,52 @@
-// TODO: renderDeadPage 테스트코드 수정하고 주석 해제
+import { useStage } from '@/stores/stage';
+import { act, screen } from '@testing-library/react';
+import { renderDeadPage } from './utils/renderPage';
+import userEvent from '@testing-library/user-event';
 
-it('1', () => {
-  expect(1).toBe(1);
+describe('DeadPage', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+
+    act(() => {
+      useStage.setState({
+        stage: 1,
+      });
+    });
+  });
+
+  it('DeadPage가 렌더링된다.', async () => {
+    await renderDeadPage();
+    await screen.findByText(/DeadPage/);
+  });
+
+  describe('현재 stage가 렌더링된다.', () => {
+    it('현재 stage가 렌더링된다.', async () => {
+      await renderDeadPage();
+      await screen.findByText(/You are dead in 1 stage/);
+    });
+    it('현재 stage가 렌더링된다.', async () => {
+      useStage.setState({
+        stage: 3,
+      });
+      await renderDeadPage();
+      await screen.findByText(/You are dead in 3 stage/);
+    });
+  });
+
+  describe('페이지 변경', () => {
+    it('Go Start Page 버튼을 누르면 StartPage로 이동한다.', async () => {
+      await renderDeadPage();
+      const button = await screen.findByRole('button', { name: /Go Start Page/ });
+      await userEvent.click(button);
+      await screen.findByText(/StartPage/);
+    });
+
+    it('Go Ranking Page 버튼을 누르면 StartPage로 이동한다.', async () => {
+      await renderDeadPage();
+      const button = await screen.findByRole('button', { name: /Go Ranking Page/ });
+      await userEvent.click(button);
+      await screen.findByText(/RankingPage/);
+    });
+  });
 });
-
-// import { useStage } from '@/stores/stage';
-// import { act, screen } from '@testing-library/react';
-// import { renderDeadPage } from './utils/renderPage';
-// import userEvent from '@testing-library/user-event';
-
-// describe('DeadPage', () => {
-//   afterEach(() => {
-//     jest.clearAllMocks();
-//     jest.restoreAllMocks();
-
-//     act(() => {
-//       useStage.setState({
-//         stage: 1,
-//       });
-//     });
-//   });
-
-//   it('1', () => {
-//     expect(1).toBe(1);
-//   });
-
-//   it('DeadPage가 렌더링된다.', async () => {
-//     await renderDeadPage();
-//     await screen.findByText(/DeadPage/);
-//   });
-
-//   describe('현재 stage가 렌더링된다.', () => {
-//     it('현재 stage가 렌더링된다.', async () => {
-//       await renderDeadPage();
-//       await screen.findByText(/You are dead in 1 stage/);
-//     });
-//     it('현재 stage가 렌더링된다.', async () => {
-//       useStage.setState({
-//         stage: 3,
-//       });
-//       await renderDeadPage();
-//       await screen.findByText(/You are dead in 3 stage/);
-//     });
-//   });
-
-//   describe('페이지 변경', () => {
-//     it('Go Start Page 버튼을 누르면 StartPage로 이동한다.', async () => {
-//       await renderDeadPage();
-//       const button = await screen.findByRole('button', { name: /Go Start Page/ });
-//       await userEvent.click(button);
-//       await screen.findByText(/StartPage/);
-//     });
-
-//     it('Go Ranking Page 버튼을 누르면 StartPage로 이동한다.', async () => {
-//       await renderDeadPage();
-//       const button = await screen.findByRole('button', { name: /Go Ranking Page/ });
-//       await userEvent.click(button);
-//       await screen.findByText(/RankingPage/);
-//     });
-//   });
-// });

--- a/tetris/src/__test__/StageIntroPage.spec.tsx
+++ b/tetris/src/__test__/StageIntroPage.spec.tsx
@@ -4,7 +4,9 @@ import { useStage } from '@/stores/stage';
 
 describe('StageIntroPage', () => {
   afterEach(() => {
-    useStage.setState({ stage: 1 });
+    act(() => {
+      useStage.setState({ stage: 1 });
+    });
   });
 
   it('StageIntroPage가 렌더링 된다.', async () => {

--- a/tetris/src/__test__/utils/renderPage.tsx
+++ b/tetris/src/__test__/utils/renderPage.tsx
@@ -76,13 +76,12 @@ export async function renderStageClearPage() {
    });
  * ```
  */
-// TODO: 테스트코드에 오류가 있음
 export async function renderDeadPage() {
   function getMockTable() {
     const result = helperModule.getEmptyTable();
     for (let col = 1; col < result.length; col++) {
       for (let row = result[0].length / 2 - 2; row < result[0].length / 2 + 2; row++) {
-        result[helperModule.SETTINGS.col - 1][row] = 'i';
+        result[col][row] = 'i';
       }
     }
     return result;
@@ -92,15 +91,7 @@ export async function renderDeadPage() {
 
   await renderPlayPage();
 
-  // act(() => {
-  //   fireEvent.keyDown(document, { key: ' ' });
-  // });
-
-  // await delay(3000);
+  act(() => {
+    fireEvent.keyDown(document, { key: ' ' });
+  });
 }
-
-// async function delay(ms: number) {
-//   return new Promise((resolve) => {
-//     setTimeout(resolve, ms);
-//   });
-// }

--- a/tetris/src/components/ui/button.tsx
+++ b/tetris/src/components/ui/button.tsx
@@ -27,7 +27,7 @@ const buttonVariants = cva(
       variant: 'default',
       size: 'default',
     },
-  },
+  }
 );
 
 export interface ButtonProps
@@ -40,7 +40,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : 'button';
     return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
-  },
+  }
 );
 Button.displayName = 'Button';
 

--- a/tetris/src/hooks/useStopWatch/useStopWatch.ts
+++ b/tetris/src/hooks/useStopWatch/useStopWatch.ts
@@ -26,7 +26,7 @@ export const useStopWatch = (delay = 1) => {
     () => {
       setTime(new Date().getTime());
     },
-    state === 'progress' ? delay : null,
+    state === 'progress' ? delay : null
   );
 
   const handleSectionRecord = () => {

--- a/tetris/src/main.tsx
+++ b/tetris/src/main.tsx
@@ -6,5 +6,5 @@ import './index.css';
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
+  </React.StrictMode>
 );

--- a/tetris/src/pages/play/_components/CellBlock.stories.tsx
+++ b/tetris/src/pages/play/_components/CellBlock.stories.tsx
@@ -40,6 +40,9 @@ export const ZCellBlock: Story = {
 export const ShadowCellBlock: Story = {
   args: { blockType: 'shadow' },
 };
+export const DisabledCellBlock: Story = {
+  args: { blockType: 'disabled' },
+};
 export const EmptyCellBlock: Story = {
   args: { blockType: null },
 };

--- a/tetris/src/pages/play/_components/CellBlock.tsx
+++ b/tetris/src/pages/play/_components/CellBlock.tsx
@@ -33,6 +33,7 @@ const colorMap = {
   t: colors.indigo[500],
   z: colors.purple[500],
   shadow: colors.gray[400],
+  disabled: colors.gray[700],
   empty: colors.gray[900],
 } satisfies Record<string, string>;
 

--- a/tetris/src/pages/play/helper/block.spec.ts
+++ b/tetris/src/pages/play/helper/block.spec.ts
@@ -2,19 +2,6 @@ import { rotateClockWiseIn2DArr } from './utils';
 import { BLOCK_MAP, combineBlockWithPosition, getBlockBottomPosition } from './block';
 import { Block } from './types';
 
-describe('getBlockBottomPosition', () => {
-  it('가로 i블록의 position이 정상적으로 렌더링된다.', () => {
-    const block = BLOCK_MAP['i'];
-    const position = { col: 1, row: 1 };
-    expect(getBlockBottomPosition(block, position)).toBe(1);
-  });
-  it('세로 i블록의 position이 정상적으로 렌더링된다.', () => {
-    const block: Block = { type: 'i', shape: rotateClockWiseIn2DArr(BLOCK_MAP['i'].shape) };
-    const position = { col: 1, row: 2 };
-    expect(getBlockBottomPosition(block, position)).toBe(4);
-  });
-});
-
 describe('combineBlockWithPosition', () => {
   describe('col이 0이고 row가 2일 때', () => {
     it('i블록이 성공적으로 변환된다.', () => {
@@ -122,5 +109,18 @@ describe('combineBlockWithPosition', () => {
       ['i', null, null, null],
       ['i', null, null, null],
     ]);
+  });
+});
+
+describe('getBlockBottomPosition', () => {
+  it('가로 i블록의 position이 정상적으로 렌더링된다.', () => {
+    const block = BLOCK_MAP['i'];
+    const position = { col: 1, row: 1 };
+    expect(getBlockBottomPosition(block, position)).toBe(1);
+  });
+  it('세로 i블록의 position이 정상적으로 렌더링된다.', () => {
+    const block: Block = { type: 'i', shape: rotateClockWiseIn2DArr(BLOCK_MAP['i'].shape) };
+    const position = { col: 1, row: 2 };
+    expect(getBlockBottomPosition(block, position)).toBe(4);
   });
 });

--- a/tetris/src/pages/play/helper/block.ts
+++ b/tetris/src/pages/play/helper/block.ts
@@ -89,7 +89,7 @@ export const combineBlockWithPosition = (block: Block, blockPosition: Position) 
   const blockColLength = block.shape.length;
   const blockRowLength = block.shape[0].length;
   const table = [...Array(Math.max(blockPosition.col, 0) + blockColLength)].map(() =>
-    Array(Math.max(blockPosition.row, 0) + blockRowLength).fill(null),
+    Array(Math.max(blockPosition.row, 0) + blockRowLength).fill(null)
   ) as Table;
   const addCol = blockPosition.col;
   const addRow = blockPosition.row;

--- a/tetris/src/pages/play/helper/block.ts
+++ b/tetris/src/pages/play/helper/block.ts
@@ -72,19 +72,6 @@ export const getRandomBlock = (random = Math.random()) => {
   return blockList[getRandom(blockList.length, random)];
 };
 
-export const getBlockBottomPosition = (block: Block, blockPosition: Position) => {
-  const blockTable = combineBlockWithPosition(block, blockPosition);
-  let max = -Infinity;
-  blockTable.forEach((col, colIndex) => {
-    col.forEach((row) => {
-      if (row !== null) {
-        max = Math.max(max, colIndex);
-      }
-    });
-  });
-  return max;
-};
-
 export const combineBlockWithPosition = (block: Block, blockPosition: Position) => {
   const blockColLength = block.shape.length;
   const blockRowLength = block.shape[0].length;
@@ -103,4 +90,17 @@ export const combineBlockWithPosition = (block: Block, blockPosition: Position) 
     });
   });
   return table;
+};
+
+export const getBlockBottomPosition = (block: Block, blockPosition: Position) => {
+  const blockTable = combineBlockWithPosition(block, blockPosition);
+  let max = -Infinity;
+  blockTable.forEach((col, colIndex) => {
+    col.forEach((row) => {
+      if (row !== null) {
+        max = Math.max(max, colIndex);
+      }
+    });
+  });
+  return max;
 };

--- a/tetris/src/pages/play/helper/index.ts
+++ b/tetris/src/pages/play/helper/index.ts
@@ -1,4 +1,4 @@
-export { getRandomBlock, getBlockMaxSize } from './block';
+export { BLOCK_MAP, getRandomBlock, getBlockMaxSize } from './block';
 export { getGoalClearLine } from './clearLine';
 export { SETTINGS } from './constants';
 export { getGameSpeed } from './speed';

--- a/tetris/src/pages/play/helper/index.ts
+++ b/tetris/src/pages/play/helper/index.ts
@@ -11,4 +11,4 @@ export {
   getUpdateTableByCompletedLines,
 } from './table';
 export * from './types';
-export { getRandom, rotateClockWiseIn2DArr } from './utils';
+export { getRandom, rotateClockWiseIn2DArr, rotateCounterClockWiseIn2DArr } from './utils';

--- a/tetris/src/pages/play/helper/table.spec.ts
+++ b/tetris/src/pages/play/helper/table.spec.ts
@@ -20,14 +20,25 @@ describe('getEmptyTable', () => {
   });
 });
 
-it('combineBlockWithTable', () => {
-  expect(combineBlockWithTable(getEmptyTable(5, 5), BLOCK_MAP['j'], { col: 0, row: 2 })).toEqual([
-    [null, null, 'j', null, null],
-    [null, null, 'j', 'j', 'j'],
-    [null, null, null, null, null],
-    [null, null, null, null, null],
-    [null, null, null, null, null],
-  ]);
+describe('combineBlockWithTable', () => {
+  it('basic', () => {
+    expect(combineBlockWithTable(getEmptyTable(5, 5), BLOCK_MAP['j'], { col: 0, row: 2 })).toEqual([
+      [null, null, 'j', null, null],
+      [null, null, 'j', 'j', 'j'],
+      [null, null, null, null, null],
+      [null, null, null, null, null],
+      [null, null, null, null, null],
+    ]);
+  });
+  it('customBlockShape을 넣은 경우 customBlockShape가 들어간다.', () => {
+    expect(combineBlockWithTable(getEmptyTable(5, 5), BLOCK_MAP['j'], { col: 0, row: 2 }, 'disabled')).toEqual([
+      [null, null, 'disabled', null, null],
+      [null, null, 'disabled', 'disabled', 'disabled'],
+      [null, null, null, null, null],
+      [null, null, null, null, null],
+      [null, null, null, null, null],
+    ]);
+  });
 });
 
 it('getTableForRenderer', () => {

--- a/tetris/src/pages/play/helper/table.spec.ts
+++ b/tetris/src/pages/play/helper/table.spec.ts
@@ -50,7 +50,7 @@ describe('findCompletedLines', () => {
         [null, 'j', null, null],
         ['j', 'j', 'j', 'j'],
         [null, 'j', null, null],
-      ]),
+      ])
     ).toEqual([1]);
   });
   it('두줄이 완성됐을 때 두 line의 index를 return한다.', () => {
@@ -59,7 +59,7 @@ describe('findCompletedLines', () => {
         ['i', 'j', 'l', 'z'],
         ['j', 'j', 'j', 'j'],
         [null, 'j', null, null],
-      ]),
+      ])
     ).toEqual([0, 1]);
   });
 });
@@ -75,8 +75,8 @@ describe('getIsPossibleRender', () => {
           [null, 'i', 'i', 'i', null, null],
         ],
         BLOCK_MAP['o'],
-        { col: 0, row: 2 },
-      ),
+        { col: 0, row: 2 }
+      )
     ).toBe(false);
   });
   it('한줄이 남아있을 때 i블록은 렌더링이 가능하다. ', () => {
@@ -89,8 +89,8 @@ describe('getIsPossibleRender', () => {
           [null, 'i', 'i', 'i', null, null],
         ],
         BLOCK_MAP['i'],
-        { col: 0, row: 2 },
-      ),
+        { col: 0, row: 2 }
+      )
     ).toBe(true);
   });
   it('row가 -1인 경우 i블록은 렌더링이 가능하다.', () => {
@@ -104,8 +104,8 @@ describe('getIsPossibleRender', () => {
           [null, null, null, null, null, null],
         ],
         block,
-        { col: 0, row: -1 },
-      ),
+        { col: 0, row: -1 }
+      )
     ).toBe(true);
   });
   it('row가 -4인 경우 i블록은 렌더링이 가능하지 않다.', () => {
@@ -119,8 +119,8 @@ describe('getIsPossibleRender', () => {
           [null, null, null, null, null, null],
         ],
         block,
-        { col: 0, row: -4 },
-      ),
+        { col: 0, row: -4 }
+      )
     ).toBe(false);
   });
   describe('position을 벗어나는 경우', () => {
@@ -134,8 +134,8 @@ describe('getIsPossibleRender', () => {
             [null, null, null, null, null, null],
           ],
           BLOCK_MAP['i'],
-          { col: 4, row: 2 },
-        ),
+          { col: 4, row: 2 }
+        )
       ).toBe(false);
     });
     it('row가 넘친다면 렌더링이 가능하지 않다.', () => {
@@ -148,8 +148,8 @@ describe('getIsPossibleRender', () => {
             [null, null, null, null, null, null],
           ],
           BLOCK_MAP['o'],
-          { col: 0, row: 5 },
-        ),
+          { col: 0, row: 5 }
+        )
       ).toBe(false);
     });
   });

--- a/tetris/src/pages/play/helper/table.ts
+++ b/tetris/src/pages/play/helper/table.ts
@@ -7,13 +7,13 @@ export const getEmptyTable = (col = SETTINGS.col, row = SETTINGS.row) => {
   return [...Array(col)].map(() => Array(row).fill(null)) as Table;
 };
 
-export const combineBlockWithTable = (table: Table, block: Block, blockPosition: Position) => {
+export const combineBlockWithTable = (table: Table, block: Block, blockPosition: Position, customBlockShape?: Cell) => {
   const blockTable = combineBlockWithPosition(block, blockPosition);
   const nextTable = produce(table, (draft) => {
     blockTable.forEach((blockShapeCol, col) => {
       blockShapeCol.forEach((blockShape, row) => {
         if (blockShape) {
-          draft[col][row] = blockShape;
+          draft[col][row] = customBlockShape ?? blockShape;
         }
       });
     });

--- a/tetris/src/pages/play/helper/table.ts
+++ b/tetris/src/pages/play/helper/table.ts
@@ -62,7 +62,7 @@ function getCellLength<T>(table: T[][]) {
         }
         return ac;
       }, 0),
-    0,
+    0
   );
 }
 
@@ -76,7 +76,7 @@ function getBlockLength<T>(table: T[][]) {
         }
         return ac;
       }, 0),
-    0,
+    0
   );
 }
 

--- a/tetris/src/pages/play/helper/types.ts
+++ b/tetris/src/pages/play/helper/types.ts
@@ -5,7 +5,7 @@ export interface Block {
   shape: BlockShape;
 }
 
-export type Cell = BlockType | 'shadow' | null;
+export type Cell = BlockType | 'shadow' | 'disabled' | null;
 export type Table = Cell[][];
 
 export type Position = { row: number; col: number };

--- a/tetris/src/pages/play/helper/utils.spec.ts
+++ b/tetris/src/pages/play/helper/utils.spec.ts
@@ -1,4 +1,4 @@
-import { getRandom, rotateClockWiseIn2DArr } from './utils';
+import { getRandom, rotateClockWiseIn2DArr, rotateCounterClockWiseIn2DArr } from './utils';
 
 describe('getRandom', () => {
   it('0을 return한다', () => {
@@ -57,6 +57,55 @@ describe('rotateClockWiseIn2DArr', () => {
       [4, 1],
       [5, 2],
       [6, 3],
+    ]);
+  });
+});
+
+describe('rotateCounterClockWiseIn2DArr', () => {
+  // 3*3
+  // 0,0 => 2,0
+  // 0,1 => 1,0
+  // 0,2 => 0,0
+
+  // 1,0 => 2,1
+  // 1,1 => 1,1
+  // 1,2 => 0,1
+
+  // 2,0 => 2,2
+  // 2,1 => 1,2
+  // 2,2 => 0,2
+  it('3*3 행렬이 성공적으로 변환된다.', () => {
+    expect(
+      rotateCounterClockWiseIn2DArr([
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ])
+    ).toEqual([
+      [3, 6, 9],
+      [2, 5, 8],
+      [1, 4, 7],
+    ]);
+  });
+
+  // 2*3
+  // 0,0 => 1,0
+  // 0,1 => 0,0
+  // 0,2 => -1,0
+
+  // 1,0 => 1,1
+  // 1,1 => 0,1
+  // 1,2 => -1,1
+  it('2*3 행렬이 성공적으로 변환된다.', () => {
+    expect(
+      rotateCounterClockWiseIn2DArr([
+        [1, 2, 3],
+        [4, 5, 6],
+      ])
+    ).toEqual([
+      [3, 6],
+      [2, 5],
+      [1, 4],
     ]);
   });
 });

--- a/tetris/src/pages/play/helper/utils.spec.ts
+++ b/tetris/src/pages/play/helper/utils.spec.ts
@@ -31,7 +31,7 @@ describe('rotateClockWiseIn2DArr', () => {
         [1, 2, 3],
         [4, 5, 6],
         [7, 8, 9],
-      ]),
+      ])
     ).toEqual([
       [7, 4, 1],
       [8, 5, 2],
@@ -52,7 +52,7 @@ describe('rotateClockWiseIn2DArr', () => {
       rotateClockWiseIn2DArr([
         [1, 2, 3],
         [4, 5, 6],
-      ]),
+      ])
     ).toEqual([
       [4, 1],
       [5, 2],

--- a/tetris/src/pages/play/helper/utils.ts
+++ b/tetris/src/pages/play/helper/utils.ts
@@ -13,3 +13,15 @@ export const rotateClockWiseIn2DArr = <T>(arr: T[][]) => {
   });
   return result;
 };
+
+export const rotateCounterClockWiseIn2DArr = <T>(arr: T[][]) => {
+  const arrColLength = arr.length;
+  const arrRowLength = arr[0].length;
+  const result = [...Array(arrRowLength)].map(() => Array(arrColLength).fill(undefined));
+  arr.forEach((colArr, col) => {
+    colArr.forEach((v, row) => {
+      result[arrRowLength - row - 1][col] = v;
+    });
+  });
+  return result;
+};

--- a/tetris/src/pages/play/hooks/useTetrisGame.spec.ts
+++ b/tetris/src/pages/play/hooks/useTetrisGame.spec.ts
@@ -154,7 +154,7 @@ describe('useTetrisGame', () => {
 
       const beforeTableForRender = result.current.tableForRender;
       act(() => {
-        result.current.handleChangeRotateBlock();
+        result.current.handleChangeClockWiseRotateBlock();
       });
 
       expect(beforeTableForRender).not.toEqual(result.current.tableForRender);
@@ -165,7 +165,7 @@ describe('useTetrisGame', () => {
       const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
       act(() => {
-        result.current.handleChangeRotateBlock();
+        result.current.handleChangeClockWiseRotateBlock();
       });
       for (let i = 0; i < helperModule.SETTINGS.row / 2; i++) {
         act(() => {
@@ -175,7 +175,7 @@ describe('useTetrisGame', () => {
 
       const beforeTableForRender = result.current.tableForRender;
       act(() => {
-        result.current.handleChangeRotateBlock();
+        result.current.handleChangeClockWiseRotateBlock();
       });
 
       expect(beforeTableForRender).not.toEqual(result.current.tableForRender);
@@ -186,7 +186,7 @@ describe('useTetrisGame', () => {
       const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
       act(() => {
-        result.current.handleChangeRotateBlock();
+        result.current.handleChangeClockWiseRotateBlock();
       });
       for (let i = 0; i < helperModule.SETTINGS.row / 2; i++) {
         act(() => {
@@ -196,7 +196,7 @@ describe('useTetrisGame', () => {
 
       const beforeTableForRender = result.current.tableForRender;
       act(() => {
-        result.current.handleChangeRotateBlock();
+        result.current.handleChangeClockWiseRotateBlock();
       });
 
       expect(beforeTableForRender).not.toEqual(result.current.tableForRender);
@@ -222,7 +222,7 @@ describe('useTetrisGame', () => {
 
       // NOTE: setState batching 때문에 여러 act로 처리
       act(() => {
-        result.current.handleChangeRotateBlock();
+        result.current.handleChangeClockWiseRotateBlock();
       });
       act(() => {
         result.current.handleChangeDownPosition();
@@ -239,7 +239,7 @@ describe('useTetrisGame', () => {
 
       const beforeTableForRender = result.current.tableForRender;
       act(() => {
-        result.current.handleChangeRotateBlock();
+        result.current.handleChangeClockWiseRotateBlock();
       });
       expect(beforeTableForRender).toEqual(result.current.tableForRender);
     });

--- a/tetris/src/pages/play/hooks/useTetrisGame.spec.ts
+++ b/tetris/src/pages/play/hooks/useTetrisGame.spec.ts
@@ -20,7 +20,7 @@ describe('useTetrisGame', () => {
     const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
     expect(result.current.clearLine).toBe(0);
-    expect(isExistCell(result.current.blockForRender)).toBe(true);
+    expect(!!result.current.nextBlock).toBe(true);
     expect(isExistCell(result.current.tableForRender)).toBe(true);
   });
 
@@ -127,13 +127,13 @@ describe('useTetrisGame', () => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
     jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0.5));
-    const beforeBlockForRender = result.current.blockForRender;
+    const nextBlock = result.current.nextBlock;
 
     act(() => {
       result.current.handleChangeLastBottomPosition();
     });
 
-    expect(beforeBlockForRender).not.toEqual(result.current.blockForRender);
+    expect(nextBlock).not.toEqual(result.current.nextBlock);
   });
 
   describe('블록 회전', () => {
@@ -274,7 +274,7 @@ describe('useTetrisGame', () => {
 
       const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
-      const beforeBlockForRender = result.current.blockForRender;
+      const nextBlock = result.current.nextBlock;
 
       jest.clearAllMocks();
       jest.restoreAllMocks();
@@ -286,7 +286,7 @@ describe('useTetrisGame', () => {
         });
       }
 
-      expect(beforeBlockForRender).not.toEqual(result.current.blockForRender);
+      expect(nextBlock).not.toEqual(result.current.nextBlock);
     });
 
     it('crash했을 때 clear한 line이 있다면 table과 clearLine이 변경된다.', () => {

--- a/tetris/src/pages/play/hooks/useTetrisGame.spec.ts
+++ b/tetris/src/pages/play/hooks/useTetrisGame.spec.ts
@@ -160,6 +160,19 @@ describe('useTetrisGame', () => {
       expect(beforeTableForRender).not.toEqual(result.current.tableForRender);
     });
 
+    it('블록이 시게반대방향으로 정상적으로 회전한다.', () => {
+      // NOTE: o블록은 회전해도 변하지 않아서 모킹이 필요함
+      jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
+      const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
+
+      const beforeTableForRender = result.current.tableForRender;
+      act(() => {
+        result.current.handleChangeCounterClockWiseRotateBlock();
+      });
+
+      expect(beforeTableForRender).not.toEqual(result.current.tableForRender);
+    });
+
     it('i블록을 회전하고 position을 맨 왼쪽으로 이동했을 때 블록이 정상적으로 회전한다.', () => {
       jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
       const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));

--- a/tetris/src/pages/play/hooks/useTetrisGame.spec.ts
+++ b/tetris/src/pages/play/hooks/useTetrisGame.spec.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import * as helperModule from '../helper';
 import { useTetrisGame } from './useTetrisGame';
 
@@ -17,7 +17,7 @@ describe('useTetrisGame', () => {
   });
 
   it('정상적으로 초기화된다.', () => {
-    const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
+    const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
     expect(result.current.clearLine).toBe(0);
     expect(isExistCell(result.current.blockForRender)).toBe(true);
@@ -25,7 +25,7 @@ describe('useTetrisGame', () => {
   });
 
   it('블록을 움직이지 않고 n개 이상 쌓인다면 onChangeStageDeadPage가 실행된다.', () => {
-    const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
+    const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
     for (let i = 0; i < helperModule.SETTINGS.row * helperModule.SETTINGS.col; i++) {
       act(() => {
@@ -40,7 +40,7 @@ describe('useTetrisGame', () => {
   });
 
   it('블록이 왼쪽으로 이동할 수 있는 경우 왼쪽으로 이동한다.', () => {
-    const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
+    const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
     const beforeTableForRender = result.current.tableForRender;
     act(() => {
@@ -51,7 +51,7 @@ describe('useTetrisGame', () => {
   });
 
   it('블록이 왼쪽으로 이동할 수 없는 경우 왼쪽으로 이동하지 않는다.', () => {
-    const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
+    const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
     for (let i = 0; i < helperModule.SETTINGS.row; i++) {
       act(() => result.current.handleChangeLeftPosition());
@@ -66,7 +66,7 @@ describe('useTetrisGame', () => {
   });
 
   it('블록이 오른쪽으로 이동할 수 있는 경우 오른쪽으로 이동한다.', () => {
-    const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
+    const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
     const beforeTableForRender = result.current.tableForRender;
     act(() => {
@@ -77,7 +77,7 @@ describe('useTetrisGame', () => {
   });
 
   it('블록이 오른쪽으로 이동할 수 없는 경우 오른쪽으로 이동하지 않는다.', () => {
-    const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
+    const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
     for (let i = 0; i < helperModule.SETTINGS.row; i++) {
       act(() => {
@@ -94,7 +94,7 @@ describe('useTetrisGame', () => {
   });
 
   it('블록이 아래로 이동할 수 있는 경우 아래로 이동한다.', () => {
-    const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
+    const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
     const beforeTableForRender = result.current.tableForRender;
     act(() => {
@@ -105,7 +105,7 @@ describe('useTetrisGame', () => {
   });
 
   it('블록이 아래로 이동할 수 없는 경우 아래로 이동하지 않는다.', () => {
-    const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
+    const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
     for (let i = 0; i < 1000; i++) {
       act(() => {
@@ -122,7 +122,7 @@ describe('useTetrisGame', () => {
 
   it('블록이 맨 아래로 이동한다.', () => {
     jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
-    const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
+    const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
     jest.clearAllMocks();
     jest.restoreAllMocks();
@@ -140,7 +140,7 @@ describe('useTetrisGame', () => {
     it('블록이 정상적으로 회전한다.', () => {
       // NOTE: o블록은 회전해도 변하지 않아서 모킹이 필요함
       jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
-      const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
+      const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
       const beforeTableForRender = result.current.tableForRender;
       act(() => {
@@ -152,7 +152,7 @@ describe('useTetrisGame', () => {
 
     it('i블록을 회전하고 position을 맨 왼쪽으로 이동했을 때 블록이 정상적으로 회전한다.', () => {
       jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
-      const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
+      const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
       act(() => {
         result.current.handleChangeRotateBlock();
@@ -173,7 +173,7 @@ describe('useTetrisGame', () => {
 
     it('i블록을 회전하고 position을 맨 오른쪽으로 이동했을 때 블록이 정상적으로 회전한다.', () => {
       jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
-      const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
+      const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
       act(() => {
         result.current.handleChangeRotateBlock();
@@ -208,7 +208,7 @@ describe('useTetrisGame', () => {
       jest.spyOn(helperModule, 'getEmptyTable').mockReturnValue(getMockTable());
       // NOTE: l 블록 모킹(7개중 3번째)
       jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(5 / 14));
-      const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
+      const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
       // NOTE: setState batching 때문에 여러 act로 처리
       act(() => {
@@ -237,7 +237,7 @@ describe('useTetrisGame', () => {
 
   describe('interval callback', () => {
     it('블록 아래 position이 비어있다면 아래로 이동한다.', () => {
-      const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
+      const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
       const beforeTableForRender = result.current.tableForRender;
       act(() => {
@@ -260,7 +260,7 @@ describe('useTetrisGame', () => {
       jest.spyOn(helperModule, 'getEmptyTable').mockReturnValue(getMockTable());
       jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
 
-      const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
+      const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
       act(() => {
         result.current.intervalCallback();
@@ -272,7 +272,7 @@ describe('useTetrisGame', () => {
     it('crash했을 때 새로운 nextBlock이 생성된다.', () => {
       jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
 
-      const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
+      const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
       const beforeBlockForRender = result.current.blockForRender;
 
@@ -300,7 +300,7 @@ describe('useTetrisGame', () => {
       jest.spyOn(helperModule, 'getEmptyTable').mockReturnValue(getMockTable());
       jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
 
-      const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
+      const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
       for (let i = 0; i < helperModule.SETTINGS.row; i++) {
         act(() => {
@@ -329,7 +329,7 @@ describe('useTetrisGame', () => {
       jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
       jest.spyOn(helperModule, 'getGoalClearLine').mockReturnValue(1);
 
-      const { result } = renderHook(() => useTetrisGame(1, onChangeStageClearPage, onChangeStageDeadPage));
+      const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
       for (let i = 0; i < helperModule.SETTINGS.row; i++) {
         act(() => {
@@ -345,6 +345,23 @@ describe('useTetrisGame', () => {
 
       expect(result.current.clearLine).toBe(1);
       expect(onChangeStageClearPage).toHaveBeenCalled();
+    });
+  });
+
+  it('handleChangeLastBottomPosition이 실행되면 gameSpeed가 변경된다.', async () => {
+    const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
+
+    expect(result.current.gameSpeed).toBe(1000);
+
+    act(async () => {
+      result.current.handleChangeLastBottomPosition();
+      await waitFor(() => {
+        expect(result.current.gameSpeed).toBe(null);
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.gameSpeed).toBe(1000);
     });
   });
 });

--- a/tetris/src/pages/play/hooks/useTetrisGame.ts
+++ b/tetris/src/pages/play/hooks/useTetrisGame.ts
@@ -67,10 +67,6 @@ export const useTetrisGame = (
   const [clearLine, setClearLine] = useState<number>(0);
   const [table, setTable] = useState<Table>(getEmptyTable(SETTINGS.col, SETTINGS.row));
 
-  const blockForRender = combineBlockWithTable(getEmptyTable(blockMaxSize, blockMaxSize + 2), nextBlock, {
-    col: 1,
-    row: 1,
-  });
   const holdBlockForRender = holdBlock
     ? combineBlockWithTable(getEmptyTable(blockMaxSize, blockMaxSize + 2), holdBlock, {
         col: 1,
@@ -193,7 +189,7 @@ export const useTetrisGame = (
 
   return {
     gameSpeed,
-    blockForRender,
+    nextBlock,
     holdBlockForRender,
     tableForRender,
     clearLine,

--- a/tetris/src/pages/play/hooks/useTetrisGame.ts
+++ b/tetris/src/pages/play/hooks/useTetrisGame.ts
@@ -1,6 +1,7 @@
 import { usePreservedCallback } from '@toss/react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
+  BLOCK_MAP,
   Block,
   Position,
   SETTINGS,
@@ -12,7 +13,6 @@ import {
   getTableForRenderer,
   getUpdateTableByCompletedLines,
   rotateClockWiseIn2DArr,
-  BLOCK_MAP,
 } from '../helper';
 
 const getInitialPosition = (block: Block) => {
@@ -47,7 +47,7 @@ export const useTetrisGame = (
 ) => {
   const { gameSpeed, isCrashed, handleCrash, handleRecoverCrash } = useCrash(initGameSpeed);
 
-  const isChangedHoldBlock = useRef<boolean>(false);
+  const [isChangedHoldBlock, setIsChangedHoldBlock] = useState<boolean>(false);
 
   const [currentBlock, setCurrentBlock] = useState<Block>(getRandomBlock());
   const [currentBlockPosition, setCurrentBlockPosition] = useState<Position>(getInitialPosition(currentBlock));
@@ -125,7 +125,7 @@ export const useTetrisGame = (
 
   // TODO: hold를 변경해서 겹치는 케이스 생각하기
   const handleChangeHoldBlock = () => {
-    if (isChangedHoldBlock.current) {
+    if (isChangedHoldBlock) {
       return;
     }
 
@@ -139,7 +139,7 @@ export const useTetrisGame = (
       setNextBlock(getRandomBlock());
       setCurrentBlockPosition(getInitialPosition(nextBlock));
     }
-    isChangedHoldBlock.current = true;
+    setIsChangedHoldBlock(true);
   };
 
   useEffect(() => {
@@ -150,7 +150,7 @@ export const useTetrisGame = (
       setNextBlock(nextBlockFor);
       setCurrentBlockPosition({ ...nextCurrentBlockPosition });
       setTable(tableForRender);
-      isChangedHoldBlock.current = false;
+      setIsChangedHoldBlock(false);
       handleRecoverCrash();
 
       const completedLines = findCompletedLines(tableForRender);

--- a/tetris/src/pages/play/hooks/useTetrisGame.ts
+++ b/tetris/src/pages/play/hooks/useTetrisGame.ts
@@ -88,7 +88,7 @@ export const useTetrisGame = (
     handleChangePosition({ col: currentBlockPosition.col + 1, row: currentBlockPosition.row });
   });
 
-  const handleChangeRotateBlock = usePreservedCallback(() => {
+  const handleChangeClockWiseRotateBlock = usePreservedCallback(() => {
     const nextBlock = { ...currentBlock, shape: rotateClockWiseIn2DArr(currentBlock.shape) };
     if (getIsPossibleRender(table, nextBlock, currentBlockPosition)) {
       setCurrentBlock(nextBlock);
@@ -182,7 +182,7 @@ export const useTetrisGame = (
     handleChangeLeftPosition,
     handleChangeRightPosition,
     handleChangeDownPosition,
-    handleChangeRotateBlock,
+    handleChangeClockWiseRotateBlock,
     handleChangeLastBottomPosition,
     handleChangeHoldBlock,
   };

--- a/tetris/src/pages/play/hooks/useTetrisGame.ts
+++ b/tetris/src/pages/play/hooks/useTetrisGame.ts
@@ -71,12 +71,6 @@ export const useTetrisGame = (
       return;
     }
 
-    const isDead = !getIsPossibleRender(tableForRender, nextBlock, getInitialPosition(nextBlock));
-    if (isDead) {
-      onChangeStageDeadPage();
-      return;
-    }
-
     handleCrash();
   });
 
@@ -136,8 +130,10 @@ export const useTetrisGame = (
   useEffect(() => {
     if (isCrashed) {
       setCurrentBlock(nextBlock);
-      setNextBlock(getRandomBlock());
-      setCurrentBlockPosition(getInitialPosition(nextBlock));
+      const nextBlockFor = getRandomBlock();
+      const nextCurrentBlockPosition = getInitialPosition(nextBlock);
+      setNextBlock(nextBlockFor);
+      setCurrentBlockPosition({ ...nextCurrentBlockPosition });
       setTable(tableForRender);
       handleRecoverCrash();
 
@@ -149,6 +145,12 @@ export const useTetrisGame = (
         if (nextClearLine >= goalClearLine) {
           onChangeStageClearPage();
         }
+      }
+
+      const isDead = !getIsPossibleRender(tableForRender, nextBlockFor, getInitialPosition(nextBlockFor));
+      if (isDead) {
+        onChangeStageDeadPage();
+        return;
       }
     }
   }, [isCrashed]);

--- a/tetris/src/pages/play/hooks/useTetrisGame.ts
+++ b/tetris/src/pages/play/hooks/useTetrisGame.ts
@@ -43,13 +43,12 @@ export const useTetrisGame = (
   });
   const { tableForRender, nextCol } = getTableForRenderer(table, currentBlock, currentBlockPosition);
 
-  const intervalCallback = () => {
-    const isPossibleDownRender = getIsPossibleRender(table, currentBlock, {
-      col: currentBlockPosition.col + 1,
-      row: currentBlockPosition.row,
-    });
+  const intervalCallback = usePreservedCallback(() => {
+    const nextPosition = { col: currentBlockPosition.col + 1, row: currentBlockPosition.row };
+    const isPossibleDownRender = getIsPossibleRender(table, currentBlock, nextPosition);
+
     if (isPossibleDownRender) {
-      setCurrentBlockPosition((position) => ({ col: position.col + 1, row: position.row }));
+      setCurrentBlockPosition(nextPosition);
       return;
     }
 
@@ -60,7 +59,7 @@ export const useTetrisGame = (
     }
 
     setIsCrashed(true);
-  };
+  });
 
   const handleChangePosition = usePreservedCallback((nextPosition: Position) => {
     if (getIsPossibleRender(table, currentBlock, { ...nextPosition })) {

--- a/tetris/src/pages/play/hooks/useTetrisGame.ts
+++ b/tetris/src/pages/play/hooks/useTetrisGame.ts
@@ -132,6 +132,7 @@ export const useTetrisGame = (
     if (holdBlock) {
       setHoldBlock(BLOCK_MAP[currentBlock.type]);
       setCurrentBlock(holdBlock);
+      setCurrentBlockPosition(getInitialPosition(nextBlock));
     } else {
       setHoldBlock(BLOCK_MAP[currentBlock.type]);
       setCurrentBlock(nextBlock);

--- a/tetris/src/pages/play/hooks/useTetrisGame.ts
+++ b/tetris/src/pages/play/hooks/useTetrisGame.ts
@@ -25,17 +25,36 @@ const getInitialPosition = (block: Block) => {
   };
 };
 
+const useCrash = (initGameSpeed: number) => {
+  const [gameSpeed, setGameSpeed] = useState<number | null>(initGameSpeed);
+  const [isCrashed, _setIsCrashed] = useState<boolean>(false);
+
+  const handleCrash = () => {
+    _setIsCrashed(true);
+    setGameSpeed(null);
+  };
+
+  const handleRecoverCrash = () => {
+    _setIsCrashed(false);
+    setGameSpeed(initGameSpeed);
+  };
+
+  return { gameSpeed, isCrashed, handleCrash, handleRecoverCrash };
+};
+
 export const useTetrisGame = (
+  initGameSpeed: number,
   goalClearLine: number,
   onChangeStageClearPage: VoidFunction,
   onChangeStageDeadPage: VoidFunction
 ) => {
+  const { gameSpeed, isCrashed, handleCrash, handleRecoverCrash } = useCrash(initGameSpeed);
+
   const [currentBlock, setCurrentBlock] = useState<Block>(getRandomBlock());
   const [currentBlockPosition, setCurrentBlockPosition] = useState<Position>(getInitialPosition(currentBlock));
   const [nextBlock, setNextBlock] = useState<Block>(getRandomBlock());
   const [clearLine, setClearLine] = useState<number>(0);
   const [table, setTable] = useState<Table>(getEmptyTable(SETTINGS.col, SETTINGS.row));
-  const [isCrashed, setIsCrashed] = useState<boolean>(false);
 
   const blockForRender = combineBlockWithTable(getEmptyTable(blockMaxSize, blockMaxSize + 2), nextBlock, {
     col: 1,
@@ -58,7 +77,7 @@ export const useTetrisGame = (
       return;
     }
 
-    setIsCrashed(true);
+    handleCrash();
   });
 
   const handleChangePosition = usePreservedCallback((nextPosition: Position) => {
@@ -111,7 +130,7 @@ export const useTetrisGame = (
 
   const handleChangeLastBottomPosition = usePreservedCallback(() => {
     setCurrentBlockPosition((position) => ({ col: nextCol, row: position.row }));
-    setIsCrashed(true);
+    handleCrash();
   });
 
   useEffect(() => {
@@ -120,7 +139,7 @@ export const useTetrisGame = (
       setNextBlock(getRandomBlock());
       setCurrentBlockPosition(getInitialPosition(nextBlock));
       setTable(tableForRender);
-      setIsCrashed(false);
+      handleRecoverCrash();
 
       const completedLines = findCompletedLines(tableForRender);
       if (completedLines.length > 0) {
@@ -135,6 +154,7 @@ export const useTetrisGame = (
   }, [isCrashed]);
 
   return {
+    gameSpeed,
     blockForRender,
     tableForRender,
     clearLine,

--- a/tetris/src/pages/play/hooks/useTetrisGame.ts
+++ b/tetris/src/pages/play/hooks/useTetrisGame.ts
@@ -13,6 +13,7 @@ import {
   getTableForRenderer,
   getUpdateTableByCompletedLines,
   rotateClockWiseIn2DArr,
+  rotateCounterClockWiseIn2DArr,
 } from '../helper';
 
 const getInitialPosition = (block: Block) => {
@@ -88,8 +89,7 @@ export const useTetrisGame = (
     handleChangePosition({ col: currentBlockPosition.col + 1, row: currentBlockPosition.row });
   });
 
-  const handleChangeClockWiseRotateBlock = usePreservedCallback(() => {
-    const nextBlock = { ...currentBlock, shape: rotateClockWiseIn2DArr(currentBlock.shape) };
+  const changeRotateBlock = (nextBlock: Block) => {
     if (getIsPossibleRender(table, nextBlock, currentBlockPosition)) {
       setCurrentBlock(nextBlock);
       return;
@@ -116,6 +116,14 @@ export const useTetrisGame = (
       setCurrentBlock(nextBlock);
       return;
     }
+  };
+
+  const handleChangeClockWiseRotateBlock = usePreservedCallback(() => {
+    changeRotateBlock({ ...currentBlock, shape: rotateClockWiseIn2DArr(currentBlock.shape) });
+  });
+
+  const handleChangeCounterClockWiseRotateBlock = usePreservedCallback(() => {
+    changeRotateBlock({ ...currentBlock, shape: rotateCounterClockWiseIn2DArr(currentBlock.shape) });
   });
 
   const handleChangeLastBottomPosition = usePreservedCallback(() => {
@@ -183,6 +191,7 @@ export const useTetrisGame = (
     handleChangeRightPosition,
     handleChangeDownPosition,
     handleChangeClockWiseRotateBlock,
+    handleChangeCounterClockWiseRotateBlock,
     handleChangeLastBottomPosition,
     handleChangeHoldBlock,
   };

--- a/tetris/src/pages/play/hooks/useTetrisGame.ts
+++ b/tetris/src/pages/play/hooks/useTetrisGame.ts
@@ -175,6 +175,7 @@ export const useTetrisGame = (
     gameSpeed,
     nextBlock,
     holdBlock,
+    isChangedHoldBlock,
     tableForRender,
     clearLine,
     intervalCallback,

--- a/tetris/src/pages/play/hooks/useTetrisGame.ts
+++ b/tetris/src/pages/play/hooks/useTetrisGame.ts
@@ -12,8 +12,8 @@ import {
   getTableForRenderer,
   getUpdateTableByCompletedLines,
   rotateClockWiseIn2DArr,
+  BLOCK_MAP,
 } from '../helper';
-import { BLOCK_MAP } from '../helper/block';
 
 const getInitialPosition = (block: Block) => {
   return {

--- a/tetris/src/pages/play/hooks/useTetrisGame.ts
+++ b/tetris/src/pages/play/hooks/useTetrisGame.ts
@@ -5,9 +5,7 @@ import {
   Position,
   SETTINGS,
   Table,
-  combineBlockWithTable,
   findCompletedLines,
-  getBlockMaxSize,
   getEmptyTable,
   getIsPossibleRender,
   getRandomBlock,
@@ -16,8 +14,6 @@ import {
   rotateClockWiseIn2DArr,
 } from '../helper';
 import { BLOCK_MAP } from '../helper/block';
-
-const blockMaxSize = getBlockMaxSize();
 
 const getInitialPosition = (block: Block) => {
   return {
@@ -43,13 +39,6 @@ const useCrash = (initGameSpeed: number) => {
   return { gameSpeed, isCrashed, handleCrash, handleRecoverCrash };
 };
 
-const holdBlockForRenderWhenBlockEmpty: Table = [
-  [null, null, null, null, null, null],
-  [null, null, null, null, null, null],
-  [null, null, null, null, null, null],
-  [null, null, null, null, null, null],
-];
-
 export const useTetrisGame = (
   initGameSpeed: number,
   goalClearLine: number,
@@ -67,12 +56,6 @@ export const useTetrisGame = (
   const [clearLine, setClearLine] = useState<number>(0);
   const [table, setTable] = useState<Table>(getEmptyTable(SETTINGS.col, SETTINGS.row));
 
-  const holdBlockForRender = holdBlock
-    ? combineBlockWithTable(getEmptyTable(blockMaxSize, blockMaxSize + 2), holdBlock, {
-        col: 1,
-        row: 1,
-      })
-    : holdBlockForRenderWhenBlockEmpty;
   const { tableForRender, nextCol } = getTableForRenderer(table, currentBlock, currentBlockPosition);
 
   const intervalCallback = usePreservedCallback(() => {
@@ -190,7 +173,7 @@ export const useTetrisGame = (
   return {
     gameSpeed,
     nextBlock,
-    holdBlockForRender,
+    holdBlock,
     tableForRender,
     clearLine,
     intervalCallback,

--- a/tetris/src/pages/play/page.tsx
+++ b/tetris/src/pages/play/page.tsx
@@ -23,6 +23,7 @@ export default function PlayPage({ stage, onChangeStageClearPage, onChangeStageD
   const {
     gameSpeed,
     blockForRender,
+    holdBlockForRender,
     tableForRender,
     clearLine,
     intervalCallback,
@@ -31,6 +32,7 @@ export default function PlayPage({ stage, onChangeStageClearPage, onChangeStageD
     handleChangeDownPosition,
     handleChangeRotateBlock,
     handleChangeLastBottomPosition,
+    handleChangeHoldBlock,
   } = useTetrisGame(initGameSpeed, goalClearLine, onChangeStageClearPage, onChangeStageDeadPage);
 
   const isSpacePressed = useRef<boolean>(false);
@@ -47,6 +49,8 @@ export default function PlayPage({ stage, onChangeStageClearPage, onChangeStageD
           return handleChangeDownPosition();
         case 'ArrowUp':
           return handleChangeRotateBlock();
+        case 'c':
+          return handleChangeHoldBlock();
         case ' ':
           if (isSpacePressed.current) {
             return;
@@ -69,6 +73,7 @@ export default function PlayPage({ stage, onChangeStageClearPage, onChangeStageD
     };
   }, [
     handleChangeDownPosition,
+    handleChangeHoldBlock,
     handleChangeLastBottomPosition,
     handleChangeLeftPosition,
     handleChangeRightPosition,
@@ -80,12 +85,16 @@ export default function PlayPage({ stage, onChangeStageClearPage, onChangeStageD
       <div className="flex flex-col items-center justify-center gap-[16px]">
         <h1 className="text-2xl">PlayPage</h1>
         <div className="flex gap-[16px]">
-          <div className="mt-auto flex w-[150px] flex-col">
-            <div>
-              time: <Timer />
-            </div>
-            <div>
-              clear lines: {clearLine} / {goalClearLine}
+          <div className="flex w-[150px] flex-col">
+            <div className="text-l">Hold Block</div>
+            <BlockRenderer cellList={holdBlockForRender} />
+            <div className="mt-auto flex flex-col">
+              <div>
+                time: <Timer />
+              </div>
+              <div>
+                clear lines: {clearLine} / {goalClearLine}
+              </div>
             </div>
           </div>
           <div className="flex flex-col">

--- a/tetris/src/pages/play/page.tsx
+++ b/tetris/src/pages/play/page.tsx
@@ -13,7 +13,7 @@ interface PlayPageProps {
 
 export default function PlayPage({ stage, onChangeStageClearPage, onChangeStageDeadPage }: PlayPageProps) {
   const goalClearLine = getGoalClearLine(stage);
-  const gameSpeed = getGameSpeed({
+  const initGameSpeed = getGameSpeed({
     currentStage: stage,
     maxSpeedTime: SETTINGS.maxSpeedTime,
     minSpeedTime: SETTINGS.minSpeedTime,
@@ -21,6 +21,7 @@ export default function PlayPage({ stage, onChangeStageClearPage, onChangeStageD
   });
 
   const {
+    gameSpeed,
     blockForRender,
     tableForRender,
     clearLine,
@@ -30,7 +31,7 @@ export default function PlayPage({ stage, onChangeStageClearPage, onChangeStageD
     handleChangeDownPosition,
     handleChangeRotateBlock,
     handleChangeLastBottomPosition,
-  } = useTetrisGame(goalClearLine, onChangeStageClearPage, onChangeStageDeadPage);
+  } = useTetrisGame(initGameSpeed, goalClearLine, onChangeStageClearPage, onChangeStageDeadPage);
 
   const isSpacePressed = useRef<boolean>(false);
   useInterval(intervalCallback, gameSpeed);

--- a/tetris/src/pages/play/page.tsx
+++ b/tetris/src/pages/play/page.tsx
@@ -2,7 +2,15 @@ import { useInterval } from '@/hooks/useInterval';
 import { useEffect, useRef } from 'react';
 import RootLayout from '../layout';
 import { BlockRenderer, TableRenderer, Timer } from './_components';
-import { SETTINGS, getGameSpeed, getGoalClearLine } from './helper';
+import {
+  SETTINGS,
+  Table,
+  combineBlockWithTable,
+  getBlockMaxSize,
+  getEmptyTable,
+  getGameSpeed,
+  getGoalClearLine,
+} from './helper';
 import { useTetrisGame } from './hooks';
 
 interface PlayPageProps {
@@ -10,6 +18,15 @@ interface PlayPageProps {
   onChangeStageClearPage: VoidFunction;
   onChangeStageDeadPage: VoidFunction;
 }
+
+const blockMaxSize = getBlockMaxSize();
+
+const holdBlockForRenderWhenBlockEmpty: Table = [
+  [null, null, null, null, null, null],
+  [null, null, null, null, null, null],
+  [null, null, null, null, null, null],
+  [null, null, null, null, null, null],
+];
 
 export default function PlayPage({ stage, onChangeStageClearPage, onChangeStageDeadPage }: PlayPageProps) {
   const goalClearLine = getGoalClearLine(stage);
@@ -22,8 +39,8 @@ export default function PlayPage({ stage, onChangeStageClearPage, onChangeStageD
 
   const {
     gameSpeed,
-    blockForRender,
-    holdBlockForRender,
+    nextBlock,
+    holdBlock,
     tableForRender,
     clearLine,
     intervalCallback,
@@ -34,6 +51,18 @@ export default function PlayPage({ stage, onChangeStageClearPage, onChangeStageD
     handleChangeLastBottomPosition,
     handleChangeHoldBlock,
   } = useTetrisGame(initGameSpeed, goalClearLine, onChangeStageClearPage, onChangeStageDeadPage);
+
+  const blockForRender = combineBlockWithTable(getEmptyTable(blockMaxSize, blockMaxSize + 2), nextBlock, {
+    col: 1,
+    row: 1,
+  });
+
+  const holdBlockForRender = holdBlock
+    ? combineBlockWithTable(getEmptyTable(blockMaxSize, blockMaxSize + 2), holdBlock, {
+        col: 1,
+        row: 1,
+      })
+    : holdBlockForRenderWhenBlockEmpty;
 
   const isSpacePressed = useRef<boolean>(false);
   useInterval(intervalCallback, gameSpeed);

--- a/tetris/src/pages/play/page.tsx
+++ b/tetris/src/pages/play/page.tsx
@@ -48,7 +48,7 @@ export default function PlayPage({ stage, onChangeStageClearPage, onChangeStageD
     handleChangeLeftPosition,
     handleChangeRightPosition,
     handleChangeDownPosition,
-    handleChangeRotateBlock,
+    handleChangeClockWiseRotateBlock,
     handleChangeLastBottomPosition,
     handleChangeHoldBlock,
   } = useTetrisGame(initGameSpeed, goalClearLine, onChangeStageClearPage, onChangeStageDeadPage);
@@ -83,7 +83,7 @@ export default function PlayPage({ stage, onChangeStageClearPage, onChangeStageD
         case 'ArrowDown':
           return handleChangeDownPosition();
         case 'ArrowUp':
-          return handleChangeRotateBlock();
+          return handleChangeClockWiseRotateBlock();
         case 'c':
           return handleChangeHoldBlock();
         case ' ':
@@ -112,7 +112,7 @@ export default function PlayPage({ stage, onChangeStageClearPage, onChangeStageD
     handleChangeLastBottomPosition,
     handleChangeLeftPosition,
     handleChangeRightPosition,
-    handleChangeRotateBlock,
+    handleChangeClockWiseRotateBlock,
   ]);
 
   return (

--- a/tetris/src/pages/play/page.tsx
+++ b/tetris/src/pages/play/page.tsx
@@ -49,6 +49,7 @@ export default function PlayPage({ stage, onChangeStageClearPage, onChangeStageD
     handleChangeRightPosition,
     handleChangeDownPosition,
     handleChangeClockWiseRotateBlock,
+    handleChangeCounterClockWiseRotateBlock,
     handleChangeLastBottomPosition,
     handleChangeHoldBlock,
   } = useTetrisGame(initGameSpeed, goalClearLine, onChangeStageClearPage, onChangeStageDeadPage);
@@ -84,6 +85,8 @@ export default function PlayPage({ stage, onChangeStageClearPage, onChangeStageD
           return handleChangeDownPosition();
         case 'ArrowUp':
           return handleChangeClockWiseRotateBlock();
+        case 'Control':
+          return handleChangeCounterClockWiseRotateBlock();
         case 'c':
           return handleChangeHoldBlock();
         case ' ':

--- a/tetris/src/pages/play/page.tsx
+++ b/tetris/src/pages/play/page.tsx
@@ -1,5 +1,5 @@
 import { useInterval } from '@/hooks/useInterval';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import RootLayout from '../layout';
 import { BlockRenderer, TableRenderer, Timer } from './_components';
 import { SETTINGS, getGameSpeed, getGoalClearLine } from './helper';
@@ -32,6 +32,7 @@ export default function PlayPage({ stage, onChangeStageClearPage, onChangeStageD
     handleChangeLastBottomPosition,
   } = useTetrisGame(goalClearLine, onChangeStageClearPage, onChangeStageDeadPage);
 
+  const isSpacePressed = useRef<boolean>(false);
   useInterval(intervalCallback, gameSpeed);
 
   useEffect(() => {
@@ -46,12 +47,24 @@ export default function PlayPage({ stage, onChangeStageClearPage, onChangeStageD
         case 'ArrowUp':
           return handleChangeRotateBlock();
         case ' ':
-          return handleChangeLastBottomPosition();
+          if (isSpacePressed.current) {
+            return;
+          }
+          handleChangeLastBottomPosition();
+          isSpacePressed.current = true;
+          return;
+      }
+    };
+    const handleKeyup = (e: KeyboardEvent) => {
+      if (e.key === ' ') {
+        isSpacePressed.current = false;
       }
     };
     document.addEventListener('keydown', handleKeydown);
+    document.addEventListener('keyup', handleKeyup);
     return () => {
       document.removeEventListener('keydown', handleKeydown);
+      document.removeEventListener('keyup', handleKeyup);
     };
   }, [
     handleChangeDownPosition,

--- a/tetris/src/pages/play/page.tsx
+++ b/tetris/src/pages/play/page.tsx
@@ -41,6 +41,7 @@ export default function PlayPage({ stage, onChangeStageClearPage, onChangeStageD
     gameSpeed,
     nextBlock,
     holdBlock,
+    isChangedHoldBlock,
     tableForRender,
     clearLine,
     intervalCallback,
@@ -58,10 +59,15 @@ export default function PlayPage({ stage, onChangeStageClearPage, onChangeStageD
   });
 
   const holdBlockForRender = holdBlock
-    ? combineBlockWithTable(getEmptyTable(blockMaxSize, blockMaxSize + 2), holdBlock, {
-        col: 1,
-        row: 1,
-      })
+    ? combineBlockWithTable(
+        getEmptyTable(blockMaxSize, blockMaxSize + 2),
+        holdBlock,
+        {
+          col: 1,
+          row: 1,
+        },
+        isChangedHoldBlock ? 'disabled' : undefined
+      )
     : holdBlockForRenderWhenBlockEmpty;
 
   const isSpacePressed = useRef<boolean>(false);

--- a/tetris/src/stores/stage.ts
+++ b/tetris/src/stores/stage.ts
@@ -19,5 +19,5 @@ export const useStage = create<Integrate>()(
   devtools((set) => ({
     ...initialState,
     increase: () => set((state) => ({ stage: state.stage + 1 })),
-  })),
+  }))
 );

--- a/tetris/src/stories/Button.tsx
+++ b/tetris/src/stories/Button.tsx
@@ -27,13 +27,7 @@ interface ButtonProps {
 /**
  * Primary UI component for user interaction
  */
-export const Button = ({
-  primary = false,
-  size = 'medium',
-  backgroundColor,
-  label,
-  ...props
-}: ButtonProps) => {
+export const Button = ({ primary = false, size = 'medium', backgroundColor, label, ...props }: ButtonProps) => {
   const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
   return (
     <button

--- a/tetris/src/stories/Header.tsx
+++ b/tetris/src/stories/Header.tsx
@@ -20,18 +20,9 @@ export const Header = ({ user, onLogin, onLogout, onCreateAccount }: HeaderProps
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">
-            <path
-              d="M10 0h12a10 10 0 0110 10v12a10 10 0 01-10 10H10A10 10 0 010 22V10A10 10 0 0110 0z"
-              fill="#FFF"
-            />
-            <path
-              d="M5.3 10.6l10.4 6v11.1l-10.4-6v-11zm11.4-6.2l9.7 5.5-9.7 5.6V4.4z"
-              fill="#555AB9"
-            />
-            <path
-              d="M27.2 10.6v11.2l-10.5 6V16.5l10.5-6zM15.7 4.4v11L6 10l9.7-5.5z"
-              fill="#91BAF8"
-            />
+            <path d="M10 0h12a10 10 0 0110 10v12a10 10 0 01-10 10H10A10 10 0 010 22V10A10 10 0 0110 0z" fill="#FFF" />
+            <path d="M5.3 10.6l10.4 6v11.1l-10.4-6v-11zm11.4-6.2l9.7 5.5-9.7 5.6V4.4z" fill="#555AB9" />
+            <path d="M27.2 10.6v11.2l-10.5 6V16.5l10.5-6zM15.7 4.4v11L6 10l9.7-5.5z" fill="#91BAF8" />
           </g>
         </svg>
         <h1>Acme</h1>

--- a/tetris/src/stories/Page.tsx
+++ b/tetris/src/stories/Page.tsx
@@ -29,18 +29,16 @@ export const Page: React.FC = () => {
           process starting with atomic components and ending with pages.
         </p>
         <p>
-          Render pages with mock data. This makes it easy to build and review page states without
-          needing to navigate to them in your app. Here are some handy patterns for managing page
-          data in Storybook:
+          Render pages with mock data. This makes it easy to build and review page states without needing to navigate to
+          them in your app. Here are some handy patterns for managing page data in Storybook:
         </p>
         <ul>
           <li>
-            Use a higher-level connected component. Storybook helps you compose such data from the
-            "args" of child component stories
+            Use a higher-level connected component. Storybook helps you compose such data from the "args" of child
+            component stories
           </li>
           <li>
-            Assemble data in the page component from your services. You can mock these services out
-            using Storybook.
+            Assemble data in the page component from your services. You can mock these services out using Storybook.
           </li>
         </ul>
         <p>


### PR DESCRIPTION
## 요약

- 기본적인 테트리스 구현을 마무리하는 pr입니다.

## 테스트 커버리지

- Uncovered line은 굳이 테스트가 필요하지 않다고 생각해서 하지 않음.
  - 에러바운더리 Fallback부분
  - Play 이벤트핸들러 연결 부분(훅 테스트를 하기 때문에 이벤트 핸들러 연동 테스트는 진행하지 않음)

<img width="570" alt="스크린샷 2024-06-09 오후 6 20 48" src="https://github.com/yoonminsang/TIL/assets/57904979/40e8bc09-f706-4272-89df-807aca93c896">


README

---

## 게임5(기타)

- space를 누르고 있을 때 여러번 이벤트가 발생하는 실수를 막는 기능 추가
- space를 누를 때 시간 delay를 초기화시키는 기능 추가
  - intervalcallback이 1초마다 실행된다고 가정했을 때 0.9초에 space를 누르면 0.1초후에 다음 블록이 내려오고 있었음. 다른 테트리스 게임으로 테스트를 해보고 delay를 초기화시키는 방법으로 변경함
- dead를 판단하는 시점 변경
  - intervalcallback에서 실행하면 계속 space를 누를때 영원히 intervalcallback이 실행되지 않아서 죽지 않는 현상 발생
  - crash가 발생했을 때 dead여부를 판단해주면 위와같은 버그도 사라지고 더 빠른 진행이 가능하다
- holdblock 기능 추가
- 시계반대방향 회전 이벤트 핸들러 추가(control)
- 블록에 대한 UI와 기능을 분리
  - 기존에는 훅에서 렌더링하기 위한 변환과정까지 끝내서 넘겨주고 있었는데 이렇게 하면 UI와 데이터가 결합되는 문제가 있다.
  - tableForRender는 현재 block과 table 두개를 결합해서 사용되고 훅 내부에서도 사용되기 때문에 일단은 훅 내부에서 관리함
- 테스트코드 오류 전부 수정