### PR TITLE
[테트리스] 랜덤하게 나오는 블록을 개선

### DIFF
--- a/tetris/src/__test__/utils/renderPage.tsx
+++ b/tetris/src/__test__/utils/renderPage.tsx
@@ -51,7 +51,11 @@ export async function renderStageClearPage() {
     return result;
   }
   jest.spyOn(helperModule, 'getEmptyTable').mockReturnValue(getMockTable());
-  jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
+  jest.spyOn(helperModule, 'getRandomBlockList').mockReturnValue(
+    Array(helperModule.BLOCK_MAX_SIZE)
+      .fill(null)
+      .map(() => helperModule.BLOCK_MAP['i'])
+  );
   jest.spyOn(helperModule, 'getGoalClearLine').mockReturnValue(1);
 
   await renderPlayPage();
@@ -87,7 +91,11 @@ export async function renderDeadPage() {
     return result;
   }
   jest.spyOn(helperModule, 'getEmptyTable').mockReturnValue(getMockTable());
-  jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
+  jest.spyOn(helperModule, 'getRandomBlockList').mockReturnValue(
+    Array(helperModule.BLOCK_MAX_SIZE)
+      .fill(null)
+      .map(() => helperModule.BLOCK_MAP['i'])
+  );
 
   await renderPlayPage();
 

--- a/tetris/src/pages/play/helper/block.spec.ts
+++ b/tetris/src/pages/play/helper/block.spec.ts
@@ -1,6 +1,25 @@
-import { rotateClockWiseIn2DArr } from './utils';
-import { BLOCK_MAP, combineBlockWithPosition, getBlockBottomPosition } from './block';
+import { BLOCK_MAP, combineBlockWithPosition, getBlockBottomPosition, getRandomBlockList } from './block';
 import { Block } from './types';
+import { rotateClockWiseIn2DArr } from './utils';
+import * as utilsModule from './utils';
+
+describe('getRandomBlockList', () => {
+  it('모든 블록을 return한다.', () => {
+    expect(Object.keys(BLOCK_MAP).sort()).toEqual(
+      getRandomBlockList()
+        .map(({ type }) => type)
+        .sort()
+    );
+  });
+
+  it('random 값에 따라 다른 블록을 return한다.', () => {
+    jest.spyOn(utilsModule, 'getRandom').mockReturnValue(utilsModule.getRandom(0));
+    const a = getRandomBlockList().map(({ type }) => type);
+    jest.spyOn(utilsModule, 'getRandom').mockReturnValue(utilsModule.getRandom(0.5));
+    const b = getRandomBlockList().map(({ type }) => type);
+    expect(a).toEqual(b);
+  });
+});
 
 describe('combineBlockWithPosition', () => {
   describe('col이 0이고 row가 2일 때', () => {

--- a/tetris/src/pages/play/helper/block.ts
+++ b/tetris/src/pages/play/helper/block.ts
@@ -67,8 +67,25 @@ export const BLOCK_MAX_SIZE = blockList.reduce((acc, cur) => {
 }, 0);
 
 // TODO: 최신 테트리스는 모든 블록이 한바퀴돌고 다음 블록이 나옴. 완전히 랜덤이 아님.
+/** @deprecated */
 export const getRandomBlock = (random = Math.random()) => {
   return blockList[getRandom(blockList.length, random)];
+};
+
+/**
+ * @description 모든 블록을 한 개씩 랜덤한 순서로 만들어주는 함수입니다.
+ *   (최신 테트리스에서는 블록이 완전히 랜덤하게 나오지 않습니다.
+ *   한 로테이션의 모든 블록이 나온 후에 다음 로테이션 블록이 나옵니다.
+ *   이 함수는 블록 리스트에서 각 블록을 하나씩 무작위 순서로 반환합니다.)
+ */
+export const getRandomBlockList = () => {
+  const result = [];
+  const remainBlockList = [...blockList];
+  for (let i = 0; i < blockList.length; i++) {
+    const [block] = remainBlockList.splice(getRandom(blockList.length - i, Math.random()), 1);
+    result.push(block);
+  }
+  return result;
 };
 
 export const combineBlockWithPosition = (block: Block, blockPosition: Position) => {

--- a/tetris/src/pages/play/helper/block.ts
+++ b/tetris/src/pages/play/helper/block.ts
@@ -66,12 +66,6 @@ export const BLOCK_MAX_SIZE = blockList.reduce((acc, cur) => {
   return Math.max(acc, cur.shape.length, cur.shape[0].length);
 }, 0);
 
-// TODO: 최신 테트리스는 모든 블록이 한바퀴돌고 다음 블록이 나옴. 완전히 랜덤이 아님.
-/** @deprecated */
-export const getRandomBlock = (random = Math.random()) => {
-  return blockList[getRandom(blockList.length, random)];
-};
-
 /**
  * @description 모든 블록을 한 개씩 랜덤한 순서로 만들어주는 함수입니다.
  *   (최신 테트리스에서는 블록이 완전히 랜덤하게 나오지 않습니다.

--- a/tetris/src/pages/play/helper/block.ts
+++ b/tetris/src/pages/play/helper/block.ts
@@ -62,11 +62,9 @@ export const BLOCK_MAP: Record<BlockType, Block> = {
 
 const blockList = Object.values(BLOCK_MAP);
 
-export const getBlockMaxSize = () => {
-  return blockList.reduce((acc, cur) => {
-    return Math.max(acc, cur.shape.length, cur.shape[0].length);
-  }, 0);
-};
+export const BLOCK_MAX_SIZE = blockList.reduce((acc, cur) => {
+  return Math.max(acc, cur.shape.length, cur.shape[0].length);
+}, 0);
 
 // TODO: 최신 테트리스는 모든 블록이 한바퀴돌고 다음 블록이 나옴. 완전히 랜덤이 아님.
 export const getRandomBlock = (random = Math.random()) => {

--- a/tetris/src/pages/play/helper/index.ts
+++ b/tetris/src/pages/play/helper/index.ts
@@ -1,4 +1,4 @@
-export { BLOCK_MAP, getRandomBlock, getBlockMaxSize } from './block';
+export { BLOCK_MAP, getRandomBlock, BLOCK_MAX_SIZE } from './block';
 export { getGoalClearLine } from './clearLine';
 export { SETTINGS } from './constants';
 export { getGameSpeed } from './speed';

--- a/tetris/src/pages/play/helper/index.ts
+++ b/tetris/src/pages/play/helper/index.ts
@@ -1,4 +1,4 @@
-export { BLOCK_MAP, getRandomBlock, getRandomBlockList, BLOCK_MAX_SIZE } from './block';
+export { BLOCK_MAP, getRandomBlockList, BLOCK_MAX_SIZE } from './block';
 export { getGoalClearLine } from './clearLine';
 export { SETTINGS } from './constants';
 export { getGameSpeed } from './speed';

--- a/tetris/src/pages/play/helper/index.ts
+++ b/tetris/src/pages/play/helper/index.ts
@@ -1,4 +1,4 @@
-export { BLOCK_MAP, getRandomBlock, BLOCK_MAX_SIZE } from './block';
+export { BLOCK_MAP, getRandomBlock, getRandomBlockList, BLOCK_MAX_SIZE } from './block';
 export { getGoalClearLine } from './clearLine';
 export { SETTINGS } from './constants';
 export { getGameSpeed } from './speed';

--- a/tetris/src/pages/play/hooks/useTetrisGame.spec.ts
+++ b/tetris/src/pages/play/hooks/useTetrisGame.spec.ts
@@ -131,12 +131,10 @@ describe('useTetrisGame', () => {
   });
 
   it('블록이 맨 아래로 이동한다.', () => {
-    jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
     const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
     jest.clearAllMocks();
     jest.restoreAllMocks();
-    jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0.5));
     const nextBlock = result.current.nextBlock;
 
     act(() => {
@@ -149,7 +147,11 @@ describe('useTetrisGame', () => {
   describe('블록 회전', () => {
     it('블록이 정상적으로 회전한다.', () => {
       // NOTE: o블록은 회전해도 변하지 않아서 모킹이 필요함
-      jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
+      jest.spyOn(helperModule, 'getRandomBlockList').mockReturnValue(
+        Array(helperModule.BLOCK_MAX_SIZE)
+          .fill(null)
+          .map(() => helperModule.BLOCK_MAP['i'])
+      );
       const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
       const beforeTableForRender = result.current.tableForRender;
@@ -162,7 +164,11 @@ describe('useTetrisGame', () => {
 
     it('블록이 시게반대방향으로 정상적으로 회전한다.', () => {
       // NOTE: o블록은 회전해도 변하지 않아서 모킹이 필요함
-      jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
+      jest.spyOn(helperModule, 'getRandomBlockList').mockReturnValue(
+        Array(helperModule.BLOCK_MAX_SIZE)
+          .fill(null)
+          .map(() => helperModule.BLOCK_MAP['i'])
+      );
       const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
       const beforeTableForRender = result.current.tableForRender;
@@ -174,7 +180,11 @@ describe('useTetrisGame', () => {
     });
 
     it('i블록을 회전하고 position을 맨 왼쪽으로 이동했을 때 블록이 정상적으로 회전한다.', () => {
-      jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
+      jest.spyOn(helperModule, 'getRandomBlockList').mockReturnValue(
+        Array(helperModule.BLOCK_MAX_SIZE)
+          .fill(null)
+          .map(() => helperModule.BLOCK_MAP['i'])
+      );
       const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
       act(() => {
@@ -195,7 +205,11 @@ describe('useTetrisGame', () => {
     });
 
     it('i블록을 회전하고 position을 맨 오른쪽으로 이동했을 때 블록이 정상적으로 회전한다.', () => {
-      jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
+      jest.spyOn(helperModule, 'getRandomBlockList').mockReturnValue(
+        Array(helperModule.BLOCK_MAX_SIZE)
+          .fill(null)
+          .map(() => helperModule.BLOCK_MAP['i'])
+      );
       const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
       act(() => {
@@ -230,7 +244,11 @@ describe('useTetrisGame', () => {
       }
       jest.spyOn(helperModule, 'getEmptyTable').mockReturnValue(getMockTable());
       // NOTE: l 블록 모킹(7개중 3번째)
-      jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(5 / 14));
+      jest.spyOn(helperModule, 'getRandomBlockList').mockReturnValue(
+        Array(helperModule.BLOCK_MAX_SIZE)
+          .fill(null)
+          .map(() => helperModule.BLOCK_MAP['l'])
+      );
       const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
       // NOTE: setState batching 때문에 여러 act로 처리
@@ -281,7 +299,11 @@ describe('useTetrisGame', () => {
         return result;
       }
       jest.spyOn(helperModule, 'getEmptyTable').mockReturnValue(getMockTable());
-      jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
+      jest.spyOn(helperModule, 'getRandomBlockList').mockReturnValue(
+        Array(helperModule.BLOCK_MAX_SIZE)
+          .fill(null)
+          .map(() => helperModule.BLOCK_MAP['i'])
+      );
 
       const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
@@ -293,15 +315,12 @@ describe('useTetrisGame', () => {
     });
 
     it('crash했을 때 새로운 nextBlock이 생성된다.', () => {
-      jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
-
       const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
       const nextBlock = result.current.nextBlock;
 
       jest.clearAllMocks();
       jest.restoreAllMocks();
-      jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0.5));
 
       for (let i = 0; i < helperModule.SETTINGS.col; i++) {
         act(() => {
@@ -321,7 +340,11 @@ describe('useTetrisGame', () => {
         return result;
       }
       jest.spyOn(helperModule, 'getEmptyTable').mockReturnValue(getMockTable());
-      jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
+      jest.spyOn(helperModule, 'getRandomBlockList').mockReturnValue(
+        Array(helperModule.BLOCK_MAX_SIZE)
+          .fill(null)
+          .map(() => helperModule.BLOCK_MAP['i'])
+      );
 
       const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
@@ -349,7 +372,11 @@ describe('useTetrisGame', () => {
         return result;
       }
       jest.spyOn(helperModule, 'getEmptyTable').mockReturnValue(getMockTable());
-      jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
+      jest.spyOn(helperModule, 'getRandomBlockList').mockReturnValue(
+        Array(helperModule.BLOCK_MAX_SIZE)
+          .fill(null)
+          .map(() => helperModule.BLOCK_MAP['i'])
+      );
       jest.spyOn(helperModule, 'getGoalClearLine').mockReturnValue(1);
 
       const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
@@ -382,9 +409,7 @@ describe('useTetrisGame', () => {
     });
 
     it('hold에 블록을 넣고 바로 시도하면 hold가 변경되지 않는다.', () => {
-      jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
       const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
-      jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0.5));
 
       act(() => {
         result.current.handleChangeHoldBlock();
@@ -400,9 +425,7 @@ describe('useTetrisGame', () => {
     });
 
     it('hold블록이 정상적으로 교환된다.', () => {
-      jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
       const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
-      jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0.5));
 
       act(() => {
         result.current.handleChangeHoldBlock();
@@ -424,7 +447,11 @@ describe('useTetrisGame', () => {
     });
 
     it('다음 블록이 바뀌지 않았을때는 hold를 변경할 수 없다.', () => {
-      jest.spyOn(helperModule, 'getRandomBlock').mockReturnValue(helperModule.getRandomBlock(0));
+      jest.spyOn(helperModule, 'getRandomBlockList').mockReturnValue(
+        Array(helperModule.BLOCK_MAX_SIZE)
+          .fill(null)
+          .map(() => helperModule.BLOCK_MAP['i'])
+      );
       const { result } = renderHook(() => useTetrisGame(1000, 1, onChangeStageClearPage, onChangeStageDeadPage));
 
       act(() => {

--- a/tetris/src/pages/play/page.tsx
+++ b/tetris/src/pages/play/page.tsx
@@ -6,7 +6,7 @@ import {
   SETTINGS,
   Table,
   combineBlockWithTable,
-  getBlockMaxSize,
+  BLOCK_MAX_SIZE,
   getEmptyTable,
   getGameSpeed,
   getGoalClearLine,
@@ -18,8 +18,6 @@ interface PlayPageProps {
   onChangeStageClearPage: VoidFunction;
   onChangeStageDeadPage: VoidFunction;
 }
-
-const blockMaxSize = getBlockMaxSize();
 
 const holdBlockForRenderWhenBlockEmpty: Table = [
   [null, null, null, null, null, null],
@@ -61,14 +59,14 @@ export default function PlayPage({ stage, onChangeStageClearPage, onChangeStageD
     handleChangeHoldBlock,
   } = useTetrisGame(initGameSpeed, goalClearLine, onChangeStageClearPage, onChangeStageDeadPage);
 
-  const blockForRender = combineBlockWithTable(getEmptyTable(blockMaxSize, blockMaxSize + 2), nextBlock, {
+  const blockForRender = combineBlockWithTable(getEmptyTable(BLOCK_MAX_SIZE, BLOCK_MAX_SIZE + 2), nextBlock, {
     col: 1,
     row: 1,
   });
 
   const holdBlockForRender = holdBlock
     ? combineBlockWithTable(
-        getEmptyTable(blockMaxSize, blockMaxSize + 2),
+        getEmptyTable(BLOCK_MAX_SIZE, BLOCK_MAX_SIZE + 2),
         holdBlock,
         {
           col: 1,


### PR DESCRIPTION
## 요약

최근 테트리스는 각각의 블록이 랜덤하게 나오지 않습니다. 7개의 블록이 로테이션을 돌면서 하나씩 나옵니다. UX 개선을 위해 해당 정책을 적용합니다.

## 테스트코드 참고사항

getRandomBlock 함수가 사라지면서 모킹도 불가능해졌습니다. 이를 대응하기 위해 getRandomBlockList 결과값을 모킹합니다.